### PR TITLE
Use cross-env for environment variables

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,8 +19,8 @@
     "lint": "TIMING=1 eslint \"src/**/*.ts\"",
     "build": "tsc --noEmit && vite build",
     "dev": "tsc --noEmit && vite build --watch",
-    "rstudio-build": "PANMIRROR_TYPES=0 PANMIRROR_SOURCEMAP=0 PANMIRROR_FORMATS=umd PANMIRROR_OUTDIR=dist-rstudio yarn build",
-    "rstudio-dev": "PANMIRROR_TYPES=0 PANMIRROR_FORMATS=umd PANMIRROR_OUTDIR=dist-rstudio yarn dev"
+    "rstudio-build": "cross-env PANMIRROR_TYPES=0 PANMIRROR_SOURCEMAP=0 PANMIRROR_FORMATS=umd PANMIRROR_OUTDIR=dist-rstudio yarn build",
+    "rstudio-dev": "cross-env PANMIRROR_TYPES=0 PANMIRROR_FORMATS=umd PANMIRROR_OUTDIR=dist-rstudio yarn dev"
   },
   "dependencies": {
     "@types/ace": "^0.0.43",
@@ -72,6 +72,7 @@
     "zenscroll": "^4.0.2"
   },
   "devDependencies": {
+    "cross-env": "7.0.3",
     "eslint": "^7.32.0",
     "eslint-config-custom": "*",
     "tsconfig": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,13 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
+cross-env@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
@@ -1087,7 +1094,7 @@ cross-fetch@3.1.5:
   dependencies:
     node-fetch "2.6.7"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
I tried to build the visual editor on Windows and the script is setting the environment variables in a way that won't work on Windows. Using `cross-env` was a quick way to get it to work vs. editing the vite config to add equivalent arguments.