### PR TITLE
fix `pandoc` import path

### DIFF
--- a/packages/editor-server/src/services/services.ts
+++ b/packages/editor-server/src/services/services.ts
@@ -22,7 +22,7 @@ import { JsonRpcServerMethod } from 'core';
 import { prefsServer, prefsServerMethods } from "./prefs";
 import { EditorServerDocuments } from "../server/server";
 import { sourceServer, sourceServerMethods } from "./source";
-import { PandocServerOptions } from "../pandoc";
+import { PandocServerOptions } from "../core/pandoc";
 import { codeViewServerMethods } from "./codeview";
 
 export {


### PR DESCRIPTION
Seems to be a missed rename after https://github.com/quarto-dev/quarto/commit/f8ec2448edb9f2176a5a4d48a47b4a50ad60b3eb.

It led to the following error during `yarn run dev-writer`:

```
writer-server:dev: /Users/seem/code/quarto/apps/writer-server/node_modules/ts-node/src/index.ts:859
writer-server:dev:     return new TSError(diagnosticText, diagnosticCodes, diagnostics);
writer-server:dev:            ^
writer-server:dev: TSError: ⨯ Unable to compile TypeScript:
writer-server:dev: ../../packages/editor-server/src/services/services.ts(25,37): error TS2307: Cannot find module '../pandoc' or its corresponding type declarations.
writer-server:dev:
writer-server:dev:     at createTSError (/Users/seem/code/quarto/apps/writer-server/node_modules/ts-node/src/index.ts:859:12)
writer-server:dev:     at reportTSError (/Users/seem/code/quarto/apps/writer-server/node_modules/ts-node/src/index.ts:863:19)
writer-server:dev:     at getOutput (/Users/seem/code/quarto/apps/writer-server/node_modules/ts-node/src/index.ts:1077:36)
writer-server:dev:     at Object.compile (/Users/seem/code/quarto/apps/writer-server/node_modules/ts-node/src/index.ts:1433:41)
writer-server:dev:     at Module.m._compile (/Users/seem/code/quarto/apps/writer-server/node_modules/ts-node/src/index.ts:1617:30)
writer-server:dev:     at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
writer-server:dev:     at Object.require.extensions.<computed> [as .ts] (/Users/seem/code/quarto/apps/writer-server/node_modules/ts-node/src/index.ts:1621:12)
writer-server:dev:     at Module.load (node:internal/modules/cjs/loader:1037:32)
writer-server:dev:     at Function.Module._load (node:internal/modules/cjs/loader:878:12)
writer-server:dev:     at Module.require (node:internal/modules/cjs/loader:1061:19) {
writer-server:dev:   diagnosticCodes: [ 2307 ]
writer-server:dev: }
```