### PR TITLE
fix: now treats .intellisense.r as plain text to avoid errors 

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -880,6 +880,9 @@
       },
       "github.copilot.enable": {
         "quarto": false
+      },
+      "files.associations": {
+          ".intellisense.r": "plaintext"
       }
     },
     "configuration": {


### PR DESCRIPTION
Fix for this issue: https://github.com/quarto-dev/quarto/issues/246. With long files quarto documents, the temp file `".intellisense.r"` exists for long enough for VScode to format it, leading to double-formatting, which can create delete lines or create syntax-error causing line breaks in the `.qmd` file.

This is anly a tiny change, by adding the following to `package.json`:

```
      "files.associations": {
          ".intellisense.r": "plaintext"
        }
```
