### PR TITLE
Rework preview/render UI to be more consistent with CLI

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -36,12 +36,10 @@
     "onLanguage:quarto",
     "onLanguage:mermaid",
     "onLanguage:dot",
-    "onCommand:quarto.render",
-    "onCommand:quarto.renderHTML",
-    "onCommand:quarto.renderPDF",
-    "onCommand:quarto.renderDOCX",
-    "onCommand:quarto.renderAll",
-    "onCommand:quarto.renderShortcut",
+    "onCommand:quarto.preview",
+    "onCommand:quarto.previewFormat",
+    "onCommand:quarto.renderDocument",
+    "onCommand:quarto.renderProject",
     "onCommand.quarto.editInSourceMode",
     "onCommand.quarto.editInVisualMode",
     "onCommand:quarto.newDocument",
@@ -257,40 +255,24 @@
         "title": "Quarto Project",
         "category": "Quarto"
       },
-
+      {
+        "command": "quarto.preview",
+        "title": "Preview",
+        "category": "Quarto"
+      },
+      {
+        "command": "quarto.previewFormat",
+        "title": "Preview Format...",
+        "category": "Quarto"
+      },
+      {
+        "command": "quarto.renderDocument",
+        "title": "Render",
+        "category": "Quarto"
+      },
       {
         "command": "quarto.renderProject",
         "title": "Render Project",
-        "category": "Quarto"
-      },
-      {
-        "command": "quarto.render",
-        "title": "Render",
-        "category": "Quarto"
-      },
-      {
-        "command": "quarto.renderShortcut",
-        "title": "Render",
-        "category": "Quarto"
-      },
-      {
-        "command": "quarto.renderHTML",
-        "title": "Render HTML",
-        "category": "Quarto"
-      },
-      {
-        "command": "quarto.renderPDF",
-        "title": "Render PDF",
-        "category": "Quarto"
-      },
-      {
-        "command": "quarto.renderDOCX",
-        "title": "Render DOCX",
-        "category": "Quarto"
-      },
-      {
-        "command": "quarto.renderAll",
-        "title": "Render All",
         "category": "Quarto"
       },
       {
@@ -411,8 +393,8 @@
         "category": "Quarto"
       },
       {
-        "command": "quarto.walkthrough.render",
-        "title": "Render",
+        "command": "quarto.walkthrough.preview",
+        "title": "Preview",
         "category": "Quarto"
       },
       {
@@ -451,7 +433,7 @@
     ],
     "keybindings": [
       {
-        "command": "quarto.renderShortcut",
+        "command": "quarto.preview",
         "key": "ctrl+shift+k",
         "mac": "cmd+shift+k"
       },
@@ -627,27 +609,21 @@
           "command": "quarto.editInSourceMode",
           "when": "activeCustomEditorId == 'quarto.visualEditor'",
           "group": "q_switch"
+        },
+        {
+          "command": "quarto.preview",
+          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'",
+          "group": "q_zPreview"
+        },
+        {
+          "command": "quarto.previewFormat",
+          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'",
+          "group": "q_zPreview"
         }
       ],
       "editor/title/run": [
         {
-          "command": "quarto.render",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'"
-        },
-        {
-          "command": "quarto.renderHTML",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'"
-        },
-        {
-          "command": "quarto.renderPDF",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'"
-        },
-        {
-          "command": "quarto.renderDOCX",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'"
-        },
-        {
-          "command": "quarto.renderAll",
+          "command": "quarto.preview",
           "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'"
         },
         {
@@ -657,19 +633,10 @@
       ],
       "notebook/toolbar": [
         {
-          "command": "quarto.render"
+          "command": "quarto.preview"
         },
         {
-          "command": "quarto.renderHTML"
-        },
-        {
-          "command": "quarto.renderPDF"
-        },
-        {
-          "command": "quarto.renderDOCX"
-        },
-        {
-          "command": "quarto.renderAll"
+          "command": "quarto.previewFormat"
         }
       ],
       "file/newFile": [
@@ -715,8 +682,16 @@
           "command": "quarto.renderProject"
         },
         {
-          "command": "quarto.render",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
+          "command": "quarto.renderDocument",
+          "when": "editorLangId == quarto ||  editorLangId == markdown || activeEditor == 'workbench.editor.notebook' || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
+        },
+        {
+          "command": "quarto.preview",
+          "when": "editorLangId == quarto || editorLangId == markdown || activeEditor == 'workbench.editor.notebook' || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
+        },
+        {
+          "command": "quarto.previewFormat",
+          "when": "editorLangId == quarto || editorLangId == markdown || activeEditor == 'workbench.editor.notebook' || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
         },
         {
           "command": "quarto.previewDiagram",
@@ -730,28 +705,8 @@
           "when": "false"
         },
         {
-          "command": "quarto.renderShortcut",
-          "when": "false"
-        },
-        {
           "command": "quarto.previewContentShortcut",
           "when": "false"
-        },
-        {
-          "command": "quarto.renderHTML",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
-        },
-        {
-          "command": "quarto.renderPDF",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
-        },
-        {
-          "command": "quarto.renderDOCX",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
-        },
-        {
-          "command": "quarto.renderAll",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
         },
         {
           "command": "quarto.clearCache",
@@ -814,7 +769,7 @@
           "when": "false"
         },
         {
-          "command": "quarto.walkthrough.render",
+          "command": "quarto.walkthrough.preview",
           "when": "false"
         },
         {
@@ -1244,8 +1199,8 @@
           },
           {
             "id": "render",
-            "title": "Render a document",
-            "description": "You can render documents to HTML, PDF, or other formats using the **Render** button on the editor toolbar, the **Cmd+Shift+K** keyboard shortcut, or the **Quarto: Render** command.\n\n[Render Document](command:quarto.walkthrough.render)",
+            "title": "Render and preview a document",
+            "description": "You can render documents to HTML, PDF, or other formats using the **Preview** button on the editor toolbar, the **Cmd+Shift+K** keyboard shortcut, or the **Quarto: Preview** command.\n\n[Preview Document](command:quarto.walkthrough.preview)",
             "media": {
               "markdown": "assets/walkthrough/empty.md"
             },

--- a/apps/vscode/src/core/terminal.ts
+++ b/apps/vscode/src/core/terminal.ts
@@ -1,0 +1,217 @@
+/*
+ * terminal.ts
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import * as os from "node:os";
+import path, { dirname } from "node:path";
+import fs from "node:fs";
+import * as child_process from "node:child_process";
+
+import which from "which";
+
+import { Uri, workspace, extensions, window } from "vscode";
+import { pathWithForwardSlashes, shQuote, sleep, winShEscape } from "core";
+import { Terminal } from "vscode";
+import { QuartoContext, fileCrossrefIndexStorage } from "quarto-core";
+import { TerminalOptions } from "vscode";
+import { previewDirForDocument, previewTargetDir } from "./doc";
+
+export interface TerminalEnv {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  QUARTO_PYTHON?: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  QUARTO_R?: string;
+}
+
+export async function terminalEnv(uri: Uri) : Promise<TerminalEnv> {
+
+  const env: TerminalEnv = {};
+
+  const workspaceFolder = workspace.getWorkspaceFolder(uri);
+
+  // QUARTO_PYTHON
+  const pyExtension = extensions.getExtension("ms-python.python");
+  if (pyExtension) {
+    if (!pyExtension.isActive) {
+      await pyExtension.activate();
+    }
+
+    const execDetails = pyExtension.exports.settings.getExecutionDetails(
+      workspaceFolder?.uri
+    );
+    if (Array.isArray(execDetails?.execCommand)) {
+      let quartoPython = execDetails.execCommand[0] as string;
+      if (!path.isAbsolute(quartoPython)) {
+        const path = which.sync(quartoPython, { nothrow: true });
+        if (path) {
+          quartoPython = path;
+        }
+      }
+      env.QUARTO_PYTHON = quartoPython;
+    }
+  }
+
+  // QUARTO_R
+  const rExtension =
+    extensions.getExtension("REditorSupport.r") ||
+    extensions.getExtension("Ikuyadeu.r");
+  if (rExtension) {
+    const rPath = workspace.getConfiguration("r.rpath", workspaceFolder?.uri);
+    let quartoR: string | undefined;
+    switch (os.platform()) {
+      case "win32": {
+        quartoR = rPath.get("windows");
+        break;
+      }
+      case "darwin": {
+        quartoR = rPath.get("mac");
+        break;
+      }
+      case "linux": {
+        quartoR = rPath.get("linux");
+        break;
+      }
+    }
+    if (quartoR) {
+      env.QUARTO_R = quartoR;
+    }
+  }
+
+  return env;
+}
+
+export function terminalOptions(name: string, target: Uri, env: TerminalEnv) {
+
+  // determine preview dir (if any)
+  const isFile = fs.statSync(target.fsPath).isFile();
+  const previewDir = isFile ? previewDirForDocument(target) : undefined;
+
+  // calculate cwd
+  const cwd = previewDir || previewTargetDir(target);
+
+  // create and show the terminal
+  const options: TerminalOptions = {
+    name,
+    cwd,
+    env: env as unknown as {
+      [key: string]: string | null | undefined;
+    },
+  };
+
+  // add crossref index path to env (will be ignored if we are in a project)
+  if (isFile) {
+    options.env!["QUARTO_CROSSREF_INDEX_PATH"] = fileCrossrefIndexStorage(
+      target.fsPath
+    );
+  }
+
+  return options;
+
+}
+
+export function terminalCommand(command: string, context: QuartoContext, target?: Uri) {
+  const quarto = "quarto"; // binPath prepended to PATH so we don't need the full form
+  const cmd: string[] = [
+    context.useCmd ? winShEscape(quarto) : shQuote(quarto),
+    command
+  ];
+  if (target) {
+    cmd.push(shQuote(
+      context.useCmd
+        ? target.fsPath
+        : pathWithForwardSlashes(target.fsPath)
+    ));
+  }
+  return cmd;
+}
+
+export async function sendTerminalCommand(
+  terminal: Terminal, 
+  terminalEnv: TerminalEnv, 
+  context: QuartoContext, 
+  cmd: string[]
+) {
+  
+  // create cmd text
+  const cmdText = context.useCmd
+      ? `cmd /C"${cmd.join(" ")}"`
+      : cmd.join(" ");
+  
+  // show the terminal
+  terminal.show(true);
+
+  // delay if required (e.g. to allow conda to initialized)
+  // wait for up to 5 seconds (note that we can do this without
+  // risk of undue delay b/c the state.isInteractedWith bit will
+  // flip as soon as the environment has been activated)
+  if (requiresTerminalDelay(terminalEnv)) {
+    const kMaxSleep = 5000;
+    const kInterval = 100;
+    let totalSleep = 0;
+    while (!terminal.state.isInteractedWith && totalSleep < kMaxSleep) {
+      await sleep(kInterval);
+      totalSleep += kInterval;
+    }
+  }
+
+  // send the command
+  terminal.sendText(cmdText, true);
+}
+
+
+export async function killTerminal(name: string, before?: () => Promise<void>) {
+  const terminal = window.terminals.find((terminal) => {
+    return terminal.name === name;
+  });
+  if (terminal) {
+    if (before) {
+      await before();
+    }
+    terminal.dispose();
+  }
+}
+
+
+function requiresTerminalDelay(env?: TerminalEnv) {
+  try {
+    if (env?.QUARTO_PYTHON) {
+      // look for virtualenv
+      const binDir = dirname(env.QUARTO_PYTHON);
+      const venvFiles = ["activate", "pyvenv.cfg", "../pyvenv.cfg"];
+      if (
+        venvFiles.map((file) => path.join(binDir, file)).some(fs.existsSync)
+      ) {
+        return true;
+      }
+
+      // look for conda env
+      const args = [
+        "-c",
+        "import sys, os; print(os.path.exists(os.path.join(sys.prefix, 'conda-meta')))",
+      ];
+      const output = (
+        child_process.execFileSync(shQuote(env.QUARTO_PYTHON), args, {
+          encoding: "utf-8",
+        }) as unknown as string
+      ).trim();
+      return output === "True";
+    } else {
+      return false;
+    }
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+}
+

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -23,6 +23,7 @@ import { quartoCellExecuteCodeLensProvider } from "./providers/cell/codelens";
 import { activateQuartoAssistPanel } from "./providers/assist/panel";
 import { activateCommon } from "./extension";
 import { activatePreview } from "./providers/preview/preview";
+import { activateRender } from "./providers/render";
 import { initQuartoContext } from "quarto-core";
 import { activateStatusBar } from "./providers/statusbar";
 import { walkthroughCommands } from "./providers/walkthrough";
@@ -94,6 +95,10 @@ export async function activate(context: vscode.ExtensionContext) {
     // walkthough
     commands.push(...walkthroughCommands(host, quartoContext));
   }
+
+  // provide render
+  const renderCommands = activateRender(quartoContext, engine);
+  commands.push(...renderCommands);
 
   // provide preview
   const previewCommands = activatePreview(context, host, quartoContext, engine);

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -405,7 +405,7 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
       },
 
       renderDocument: async () => {
-        await commands.executeCommand("quarto.renderShortcut");
+        await commands.executeCommand("quarto.preview");
       },
 
       // map resources to uris valid in the editor

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -29,21 +29,6 @@ import { MarkdownEngine } from "../../markdown/engine";
 import { documentFrontMatter } from "../../markdown/document";
 
 
-export function previewDirForDocument(uri: Uri) {
-  // first check for a quarto project
-  const projectDir = projectDirForDocument(uri.fsPath);
-  if (projectDir) {
-    return projectDir;
-  } else {
-    // now check if we are within a workspace root
-    const workspaceDir = workspace.getWorkspaceFolder(uri);
-    if (workspaceDir) {
-      return workspaceDir.uri.fsPath;
-    }
-  }
-  return undefined;
-}
-
 export async function isQuartoShinyDoc(
   engine: MarkdownEngine,
   doc?: TextDocument

--- a/apps/vscode/src/providers/render.ts
+++ b/apps/vscode/src/providers/render.ts
@@ -1,0 +1,283 @@
+/*
+ * render.ts
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { workspace, window } from "vscode";
+
+import semver from "semver";
+
+import { QuartoContext, projectDirForDocument, quartoDocumentFormats, quartoProjectConfig } from "quarto-core";
+
+import { Command } from "../core/command";
+
+import { MarkdownEngine } from "../markdown/engine";
+import { promptForQuartoInstallation } from "../core/quarto";
+import { QuartoEditor, canPreviewDoc, findQuartoEditor, isNotebook } from "../core/doc";
+import { commands } from "vscode";
+import { killTerminal, sendTerminalCommand, terminalCommand, terminalEnv, terminalOptions } from "../core/terminal";
+import { QuickPickItem } from "vscode";
+import { documentFrontMatterYaml } from "../markdown/document";
+import { QuickPickItemKind } from "vscode";
+import { Uri } from "vscode";
+
+export function activateRender(quartoContext: QuartoContext, engine: MarkdownEngine) : Command[] {
+  return [
+    new RenderDocumentCommand(quartoContext, engine),
+    new RenderProjectCommand(quartoContext, engine),
+  ];
+}
+
+export abstract class RenderCommand {
+  constructor(quartoContext: QuartoContext) {
+    this.quartoContext_ = quartoContext;
+  }
+  async execute() {
+    if (this.quartoContext_.available) {
+      const kRequiredVersion = "0.9.149";
+      if (semver.gte(this.quartoContext_.version, kRequiredVersion)) {
+        await this.doExecute();
+      } else {
+        window.showWarningMessage(
+          `Rendering requires Quarto version ${kRequiredVersion} or greater`,
+          { modal: true }
+        );
+      }
+    } else {
+      await promptForQuartoInstallation("before rendering documents", true);
+    }
+  }
+  protected abstract doExecute(): Promise<void>;
+  protected quartoContext() { return this.quartoContext_; }
+  private readonly quartoContext_: QuartoContext;
+}
+
+export interface FormatQuickPickItem extends QuickPickItem {
+  format: string;
+}
+
+
+
+class RenderDocumentCommand extends RenderCommand
+  implements Command
+{
+  constructor(quartoContext: QuartoContext, private readonly engine_: MarkdownEngine) {
+    super(quartoContext);
+  }
+  private static readonly id = "quarto.renderDocument";
+  public readonly id = RenderDocumentCommand.id;
+
+  protected async doExecute() {
+
+    const targetEditor = findQuartoEditor(this.engine_, this.quartoContext(), canPreviewDoc);
+    if (targetEditor) {
+
+      // show the editor and save
+      if (!isNotebook(targetEditor.document)) {
+        await targetEditor.activate();
+      }
+      await commands.executeCommand("workbench.action.files.save");
+      
+      // kill any existing terminal
+      const kQuartoRenderTitle = "Quarto Render";
+      await killTerminal(kQuartoRenderTitle);
+
+      // resolve format
+      const format = await this.resolveFormat(targetEditor);
+      if (format === undefined) {
+        return;
+      }
+      
+      // create new terminal
+      const target = targetEditor.document.uri;
+      const env = await terminalEnv(target);
+      const options = terminalOptions(kQuartoRenderTitle, target, env);
+      const terminal = window.createTerminal(options);
+
+      // build terminal command and send it
+      const cmd = terminalCommand("render", this.quartoContext(), target);
+      if (format !== "default") {
+        cmd.push("--to");
+        cmd.push(format);
+      }
+      await sendTerminalCommand(terminal, env, this.quartoContext(), cmd);
+      
+      // focus the editor (sometimes the terminal steals focus)
+      if (!isNotebook(targetEditor.document)) {
+        await targetEditor.activate();
+      }
+
+    }
+  }
+
+  private async resolveFormat(targetEditor: QuartoEditor) {
+    return new Promise<string | undefined>((resolve) => {
+      
+      const frontMatter = targetEditor.notebook 
+        ? targetEditor.notebook.cellAt(0)?.document.getText() || ""
+        : documentFrontMatterYaml(this.engine_, targetEditor.document);
+
+      const formats = quartoDocumentFormats(this.quartoContext().runQuarto, targetEditor.document.uri.fsPath, frontMatter);
+      if (formats && formats.length > 1) {
+        const quickPick = window.createQuickPick<FormatQuickPickItem>();
+        quickPick.canSelectMany = false;
+        quickPick.items = [
+          {
+            format: "all",
+            label: `$(run-all) Render All Formats`,
+            detail: `formats: ${formats.map(format => format.format).join(', ')}`,
+            alwaysShow: true,
+          },
+          {
+            format: "default",
+            label: "",
+            kind: QuickPickItemKind.Separator,
+          },
+          ...formats.map(format => ({
+            format: format.format,
+            label: `$(play) Render ${format.name}`,
+            detail: `format: ${format.format}`,
+            alwaysShow: true
+          }))
+        ];
+        
+        let accepted = false;
+        quickPick.onDidAccept(async () => {
+          accepted = true;
+          quickPick.hide();
+          const chosenFormat = quickPick.selectedItems[0].format;
+          resolve(chosenFormat);
+        });
+        quickPick.onDidHide(() => {
+          if (!accepted) {
+            resolve(undefined);
+          }
+        });
+        quickPick.show();
+      } else {
+        resolve("default");
+      }
+    });
+  }
+  
+}
+
+
+class RenderProjectCommand extends RenderCommand implements Command {
+  private static readonly id = "quarto.renderProject";
+  public readonly id = RenderProjectCommand.id;
+
+  constructor(quartoContext: QuartoContext,
+              private readonly engine_: MarkdownEngine) {
+    super(quartoContext);
+  }
+
+  async doExecute() {
+    await workspace.saveAll(false);
+
+    // determine the project dir
+    let projectDir: Uri | undefined;
+    const targetEditor = findQuartoEditor(this.engine_, this.quartoContext(), canPreviewDoc);
+    if (targetEditor) {
+      const docProjectDir = projectDirForDocument(targetEditor.document.uri.fsPath);
+      if (docProjectDir) {
+        projectDir = Uri.file(docProjectDir);
+      }
+    }
+    
+    // if we didn't find it yet use the workspace
+    if (!projectDir && workspace.workspaceFolders) {
+      for (const folder of workspace.workspaceFolders) {
+        const config = await quartoProjectConfig(this.quartoContext().runQuarto, folder.uri.fsPath);
+        if (config) {
+          projectDir = folder.uri;
+        }
+      }
+    }
+
+  
+    // render if we have a project dir
+    if (projectDir) {
+    
+       // kill any existing terminal
+       const kQuartoRenderTitle = "Quarto Render";
+       await killTerminal(kQuartoRenderTitle);
+ 
+       // determine format
+       const format = await this.resolveFormat(projectDir);
+       if (format === undefined) {
+          return;
+       }
+
+       // create new terminal
+       const env = await terminalEnv(projectDir);
+       const options = terminalOptions(kQuartoRenderTitle, projectDir, env);
+       const terminal = window.createTerminal(options);
+ 
+       // build terminal command and send it
+       const cmd = terminalCommand("render", this.quartoContext());
+       if (format !== "default") {
+        cmd.push("--to");
+        cmd.push(format);
+       }
+       await sendTerminalCommand(terminal, env, this.quartoContext(), cmd);
+    } else {
+      // no project found!
+      window.showInformationMessage("No project available to render.");
+    }
+  }
+
+  private async resolveFormat(projectDir: Uri) : Promise<string | undefined> {
+    return new Promise(async (resolve) => {
+      const config = await quartoProjectConfig(this.quartoContext().runQuarto, projectDir.fsPath);
+      if (config?.config.project.type === "book" && typeof(config?.config.format) === "object") {
+        const formats = Object.keys(config?.config.format);
+        const quickPick = window.createQuickPick<FormatQuickPickItem>();
+        quickPick.canSelectMany = false;
+        quickPick.items = [
+          {
+            format: "all",
+            label: `$(run-all) Render All Formats`,
+            alwaysShow: true,
+          },
+          {
+            format: "default",
+            label: "",
+            kind: QuickPickItemKind.Separator,
+          },
+          ...formats.map(format => ({
+            format: format,
+            label: `$(play) Render ${format} book`,
+            alwaysShow: true
+          }))
+        ];
+        let accepted = false;
+        quickPick.onDidAccept(async () => {
+          accepted = true;
+          quickPick.hide();
+          const chosenFormat = quickPick.selectedItems[0].format;
+          resolve(chosenFormat);
+        });
+        quickPick.onDidHide(() => {
+          if (!accepted) {
+            resolve(undefined);
+          }
+        });
+        quickPick.show();
+      } else {
+        resolve("default");
+      }
+    });
+   
+  }
+}

--- a/packages/editor/src/api/presentation.ts
+++ b/packages/editor/src/api/presentation.ts
@@ -16,7 +16,7 @@
 import { EditorState } from 'prosemirror-state';
 
 import { findTopLevelBodyNodes } from './node';
-import { parseYaml, titleFromState, valueFromYamlText, yamlFrontMatter } from './yaml';
+import { titleFromState, valueFromYamlText, yamlFrontMatter } from './yaml';
 
 export interface PresentationEditorLocation {
   items: PresentationEditorLocationItem[];


### PR DESCRIPTION
This PR revamps the preview/render UI to be more consistent with the CLI. This should be conceptually more clear as well as enable more flexible workflows (e.g. toggling between the preview of different formats without changing source code, rendering without previewing, rendering specific formats, etc).

#### 1) The main editor button is now "Preview" rather than "Render":

<img width="632" alt="Screen Shot 2023-09-24 at 8 27 19 AM" src="https://github.com/quarto-dev/quarto/assets/104391/b1a7992c-8d8a-4eb0-998d-bd24b96a9379">


#### 2) There is now a "Preview Format" command (also accessible from the editor drop down menu) which reads the formats targeted by a document and presents a choice between them:

<img width="635" alt="Screen Shot 2023-09-24 at 8 28 45 AM" src="https://github.com/quarto-dev/quarto/assets/104391/2cf174cf-a23d-4e8b-a1fe-8b299f069985">

<img width="646" alt="Screen Shot 2023-09-24 at 8 30 14 AM" src="https://github.com/quarto-dev/quarto/assets/104391/3bed07ec-e0da-4a6f-8968-a33a2ee9539f">


Note that after "Preview Format" is used hitting the "Preview" button (or using Cmd+Shift+K) will preview the newly selected format rather than the default format.

#### 3) The "Render" command now _only_ executes a render (no preview). If there are multiple formats then a quick pick enabling target selection is provided:

<img width="646" alt="Screen Shot 2023-09-24 at 8 38 28 AM" src="https://github.com/quarto-dev/quarto/assets/104391/dd3ce1ec-ce30-4550-9ab4-7470dadbef60">



