### PR TITLE
OJS: fix broken error message

### DIFF
--- a/packages/ojs/quarto-ojs-runtime/package.json
+++ b/packages/ojs/quarto-ojs-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quarto-ojs-runtime",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A runtime for quarto's support of ObservableHQ's reactive Javascript.",
   "main": "src/index.js",
   "module": "src/index.js",

--- a/packages/ojs/quarto-ojs-runtime/src/quarto-ojs.js
+++ b/packages/ojs/quarto-ojs-runtime/src/quarto-ojs.js
@@ -60,6 +60,7 @@ function displayOJSWarning(warning)
 
     cell.appendChild(
       calloutBlock({
+        heading: "Error",
         type: "error",
         message
       })


### PR DESCRIPTION
This fixes a bug in quarto-cli. (I already updated the build files over there, so quarto-cli is not blocked in merging this. But it'd be good to have things in sync).