### PR TITLE
remove --no-watch-inputs from vscode quarto preview

### DIFF
--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -460,7 +460,6 @@ class PreviewManager {
       }
 
       cmd.push("--no-browser");
-      cmd.push("--no-watch-inputs");
     }
 
     // send terminal command


### PR DESCRIPTION
The `Quarto: Preview` is not watching input changes in VSCode. This is an attempt to get the VSCode extension to behave closer to the CLI.