### PR TITLE
feat(vscode): support PRQL comment charactor

### DIFF
--- a/apps/vscode/src/providers/option.ts
+++ b/apps/vscode/src/providers/option.ts
@@ -141,4 +141,5 @@ const kLangCommentChars: Record<string, string> = {
   haskell: "--",
   dot: "//",
   mermaid: "%%",
+  prql: "#",
 };


### PR DESCRIPTION
Related to quarto-dev/quarto-cli#4147 and quarto-dev/quarto-cli#4838

I would like to get the PRQL code block to work properly on VS Code.
Would this change be sufficient?
(Sorry, I'm not familiar with the code and don't understand how to test this)