### PR TITLE
change nomenclature: horizontal rule => line

### DIFF
--- a/apps/vscode/snippets/quarto.code-snippets
+++ b/apps/vscode/snippets/quarto.code-snippets
@@ -92,9 +92,9 @@
     "description": "Insert ordered list"
   },
   "Insert horizontal rule": {
-    "prefix": "horizontal rule",
+    "prefix": ["horizontal rule", "horizontal line"]
     "body": "----------\n",
-    "description": "Insert horizontal rule"
+    "description": "Insert horizontal line"
   },
   "Insert link": {
     "prefix": "link",

--- a/packages/editor-ui/src/i18n/locales/en/commands.json
+++ b/packages/editor-ui/src/i18n/locales/en/commands.json
@@ -37,7 +37,7 @@
   "remove_link_menu_text": "Remove Link",
   "footnote_menu_text": "Footnote",
   "paragraph_insert_menu_text": "Paragraph",
-  "horizontal_rule_menu_text": "Horizontal Rule",
+  "horizontal_rule_menu_text": "Horizontal Line",
   "inline_math_menu_text": "Inline Math",
   "display_math_menu_text": "Display Math",
   "inline_latex_menu_text": "TeX Inline",


### PR DESCRIPTION
Follow up on https://github.com/quarto-dev/quarto/commit/61fee2a549d7c549c708f06d4f93bd765c922f2c

where we did this now
https://github.com/quarto-dev/quarto/blob/082a5b133d5802fe487ff73c6e002b56e22a0433/packages/editor/src/nodes/hr.ts#L85-L95

This closes https://github.com/quarto-dev/quarto/issues/350

Is this nomenclature change expected everywhere ? This PR assumes that. 