### PR TITLE
Render output in a temp directory, when in an R package

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1073,6 +1073,13 @@
           "default": true,
           "markdownDescription": "Reveal the preview panel after document render."
         },
+        "quarto.render.rPackageOutputDirectory": {
+          "order": 15,
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Render output files in a temporary directory, when in an R package."
+        },
         "quarto.visualEditor.fontSize": {
           "order": 31,
           "scope": "resource",

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -59,8 +59,11 @@ export function isQuartoShinyKnitrDoc(
   
 }
 
-export async function isRPackage() {
+export async function isRPackage(): Promise<boolean> {
   const descriptionLines = await parseRPackageDescription();
+  if (!descriptionLines) {
+    return false;
+  }
   const packageLines = descriptionLines.filter(line => line.startsWith('Package:'));
   const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
   const typeIsPackage = (typeLines.length > 0

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -59,6 +59,30 @@ export function isQuartoShinyKnitrDoc(
   
 }
 
+export async function isRPackage() {
+  const descriptionLines = await parseRPackageDescription();
+	const packageLines = descriptionLines.filter(line => line.startsWith('Package:'));
+	const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
+	const typeIsPackage = (typeLines.length > 0
+		? typeLines[0].toLowerCase().includes('package')
+		: false);
+	const typeIsPackageOrMissing = typeLines.length === 0 || typeIsPackage;
+	return packageLines.length > 0 && typeIsPackageOrMissing;
+}
+
+async function parseRPackageDescription(): Promise<string[]> {
+	if (vscode.workspace.workspaceFolders !== undefined) {
+		const folderUri = vscode.workspace.workspaceFolders[0].uri;
+		const fileUri = vscode.Uri.joinPath(folderUri, 'DESCRIPTION');
+		try {
+			const bytes = await vscode.workspace.fs.readFile(fileUri);
+			const descriptionText = Buffer.from(bytes).toString('utf8');
+			const descriptionLines = descriptionText.split(/(\r?\n)/);
+			return descriptionLines;
+		} catch { }
+	}
+	return [''];
+}
 
 export async function renderOnSave(engine: MarkdownEngine, document: TextDocument) {
   // if its a notebook and we don't have a save hook for notebooks then don't

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -61,27 +61,27 @@ export function isQuartoShinyKnitrDoc(
 
 export async function isRPackage() {
   const descriptionLines = await parseRPackageDescription();
-	const packageLines = descriptionLines.filter(line => line.startsWith('Package:'));
-	const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
-	const typeIsPackage = (typeLines.length > 0
-		? typeLines[0].toLowerCase().includes('package')
-		: false);
-	const typeIsPackageOrMissing = typeLines.length === 0 || typeIsPackage;
-	return packageLines.length > 0 && typeIsPackageOrMissing;
+  const packageLines = descriptionLines.filter(line => line.startsWith('Package:'));
+  const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
+  const typeIsPackage = (typeLines.length > 0
+    ? typeLines[0].toLowerCase().includes('package')
+    : false);
+  const typeIsPackageOrMissing = typeLines.length === 0 || typeIsPackage;
+  return packageLines.length > 0 && typeIsPackageOrMissing;
 }
 
 async function parseRPackageDescription(): Promise<string[]> {
-	if (vscode.workspace.workspaceFolders !== undefined) {
-		const folderUri = vscode.workspace.workspaceFolders[0].uri;
-		const fileUri = vscode.Uri.joinPath(folderUri, 'DESCRIPTION');
-		try {
-			const bytes = await vscode.workspace.fs.readFile(fileUri);
-			const descriptionText = Buffer.from(bytes).toString('utf8');
-			const descriptionLines = descriptionText.split(/(\r?\n)/);
-			return descriptionLines;
-		} catch { }
-	}
-	return [''];
+  if (vscode.workspace.workspaceFolders !== undefined) {
+    const folderUri = vscode.workspace.workspaceFolders[0].uri;
+    const fileUri = vscode.Uri.joinPath(folderUri, 'DESCRIPTION');
+    try {
+      const bytes = await vscode.workspace.fs.readFile(fileUri);
+      const descriptionText = Buffer.from(bytes).toString('utf8');
+      const descriptionLines = descriptionText.split(/(\r?\n)/);
+      return descriptionLines;
+    } catch { }
+  }
+  return [''];
 }
 
 export async function renderOnSave(engine: MarkdownEngine, document: TextDocument) {

--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -74,6 +74,7 @@ import {
   haveNotebookSaveEvents,
   isQuartoShinyDoc,
   isQuartoShinyKnitrDoc,
+  isRPackage,
   renderOnSave,
 } from "./preview-util";
 
@@ -448,6 +449,9 @@ class PreviewManager {
     // terminal options
     const options = terminalOptions(kPreviewWindowTitle, target, this.previewEnv_);
 
+    // is this workspace an R package?
+    const isRPackageWorkspace = await isRPackage();
+
     // is this is a shiny doc?
     const isShiny = isQuartoShinyDoc(this.engine_, doc);
     const useServeCommand = this.usesQuartoServeCommand(doc);
@@ -475,6 +479,11 @@ class PreviewManager {
 
       cmd.push("--no-browser");
       cmd.push("--no-watch-inputs");
+    }
+
+    // use temp output-dir for R package
+    if (isRPackageWorkspace && this.previewRPackageDirConfig()) {
+      cmd.push("--output-dir", tmp.dirSync().name);
     }
 
     // send terminal command
@@ -709,6 +718,10 @@ class PreviewManager {
 
   private previewRevealConfig(): boolean {
     return this.quartoConfig().get("render.previewReveal", true);
+  }
+
+  private previewRPackageDirConfig(): boolean {
+    return this.quartoConfig().get("render.rPackageOutputDirectory", true);
   }
 
   private quartoConfig() {

--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -484,6 +484,7 @@ class PreviewManager {
     // use temp output-dir for R package
     if (isRPackageWorkspace && this.previewRPackageDirConfig()) {
       cmd.push("--output-dir", tmp.dirSync().name);
+      cmd.push("--embed-resources");
     }
 
     // send terminal command


### PR DESCRIPTION
This PR updates the preview behavior so by default output files go to a temporary directory when the workspace is an R package.