### PR TITLE
Check for new Quarto version for R pkg support

### DIFF
--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -377,8 +377,8 @@ class PreviewManager {
   }
 
   private usesQuartoServeCommand(doc?: TextDocument) {
-    return isQuartoShinyKnitrDoc(this.engine_, doc) ||    
-           (isQuartoShinyDoc(this.engine_, doc) && semver.lte(this.quartoContext_.version, "1.4.414"));
+    return isQuartoShinyKnitrDoc(this.engine_, doc) ||
+      (isQuartoShinyDoc(this.engine_, doc) && semver.lte(this.quartoContext_.version, "1.4.414"));
   }
 
   private previewRenderRequest(doc: TextDocument, format: string | null) {
@@ -414,7 +414,7 @@ class PreviewManager {
   }
 
   private async killPreview() {
-    await killTerminal(kPreviewWindowTitle, async () =>  await this.previewTerminateRequest());
+    await killTerminal(kPreviewWindowTitle, async () => await this.previewTerminateRequest());
     this.progressDismiss();
     this.progressCancellationToken_ = undefined;
   }
@@ -466,7 +466,7 @@ class PreviewManager {
 
     // create base terminal command
     const cmd = terminalCommand(useServeCommand ? "serve" : "preview", this.quartoContext_, target);
-    
+
     // extra args for normal docs
     if (!useServeCommand) {
       if (!doc) {
@@ -483,8 +483,17 @@ class PreviewManager {
 
     // use temp output-dir for R package
     if (isRPackageWorkspace && this.previewRPackageDirConfig()) {
-      cmd.push("--output-dir", tmp.dirSync().name);
-      cmd.push("--embed-resources");
+      const rPkgRequiredVersion = "1.5.39";
+      if (semver.gte(this.quartoContext_.version, rPkgRequiredVersion)) {
+        cmd.push("--output-dir", tmp.dirSync().name);
+        cmd.push("--embed-resources");
+      } else {
+        window.showWarningMessage(
+          `Rendering requires Quarto version ${rPkgRequiredVersion} or greater`,
+          { modal: true }
+        );
+        return;
+      }
     }
 
     // send terminal command
@@ -698,7 +707,7 @@ class PreviewManager {
   }
 
   private zoomLevel(uri?: Uri) {
-    if (uri === undefined ||isHtmlContent(uri.toString())) {
+    if (uri === undefined || isHtmlContent(uri.toString())) {
       return this.webviewManager_.getZoomLevelConfig();
     } else {
       return undefined;


### PR DESCRIPTION
Related to #435 

As folks have started using this, we realized we need to make sure they have the right version of Quarto itself! This adds the same kind of `window.showWarningMessage()` as is [used here](https://github.com/quarto-dev/quarto/blob/f0d4538e8b36abf22871ffd80eb0c82406b7ca73/apps/vscode/src/providers/render.ts#L59).

I chose the Quarto version that also has the fix for `.quarto` directories. Warning if you have an older Quarto looks like this:

![warning-version-window](https://github.com/quarto-dev/quarto/assets/12505835/cbec9529-5a1e-4c66-99cf-13beb3d52634)

The early return keeps the document from rendering but it _will_ still have opened a new terminal. I tend to think that's OK.

There's a couple of whitespace changes in this file from the new formatting added in b47a56d57a6a5c5eeba54558f95533fed2472ace.