### PR TITLE
Look for Quarto in the app root (for Positron)

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -55,6 +55,8 @@ export async function activate(context: vscode.ExtensionContext) {
   const quartoContext = initQuartoContext(
     quartoPath,
     workspaceFolder,
+    // Look for quarto in the app root; this is where Positron installs it
+    [path.join(vscode.env.appRoot, 'quarto', 'bin')],
     vscode.window.showWarningMessage
   );
   if (quartoContext.available) {


### PR DESCRIPTION
This change allows the Quarto extension to discover a version of Quarto installed (bundled with) Positron. See https://github.com/posit-dev/positron/pull/4212 for details on how Quarto is bundled with Positron.

Since Positron installation locations can vary, and we don't want the installed version of Quarto to take precedence over other installations, the approach taken here is to add the `quarto/bin` folder of the app root to the list of paths to scan for Quarto. 