### PR TITLE
suppress background highlight on first line

### DIFF
--- a/packages/editor/src/editor/editor-theme.ts
+++ b/packages/editor/src/editor/editor-theme.ts
@@ -416,6 +416,7 @@ export function applyTheme(theme: EditorTheme) {
     .pm-ace-first-line-meta .ace_text-layer .ace_line_group:first-child,
     .pm-ace-first-line-meta .ace_text-layer .ace_line_group:first-child span {
       color: ${theme.lightTextColor} !important;
+      background: none !important;
     }
     .pm-ace-collapsed.pm-ace-focused {
       border-color: ${theme.paneBorderColor} !important;


### PR DESCRIPTION
Some Ace highlight rules will also give tokens a background highlight color. For example, Stan's highlight rules (in RStudio) give `var` a red background highlight. Unfortunately, these highlight rules also apply to tokens on the first line, and so we can end up with a chunk like so:

<img width="256" alt="Screenshot 2024-09-11 at 3 09 37 PM" src="https://github.com/user-attachments/assets/496b86d6-24a9-45e9-8236-a914b5acccaf">

This PR alleviates that by forcing `background: none !important` in the CSS for panmirror.