### PR TITLE
Use user's selected `language` for next code cell

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.115.0
 
+- In Source Mode, `Insert Code Cell` now places your cursor directly into the code cell if you've already specified the language in a previous cell (<https://github.com/quarto-dev/quarto/pull/540>).
 - Improved reliability of sequential execution of code cells in Positron (<https://github.com/quarto-dev/quarto/pull/510>).
 
 ## 1.114.0 (Release on 06 Aug 2024)

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -98,17 +98,22 @@ class InsertCodeCellCommand implements Command {
           }
         }
 
-        // order by language
-        const allLangs = ['python', 'r', 'julia', 'ojs', 'sql', 'bash', 'mermaid', 'dot'];
-        const languages = language 
-          ? [language, allLangs.filter(lang => lang !== language)]
-          : allLangs;
-        
+        // if we have a known language, use it and put the cursor directly in the
+        // code cell, otherwise let the user select the language first
+        let header;
+
+        if (language) {
+          header = "```{" + language + "}";
+        } else {
+          const languages = ['python', 'r', 'julia', 'ojs', 'sql', 'bash', 'mermaid', 'dot'];
+          header = "```{${1|" + languages.join(",") + "|}}";
+        }
+
         // insert snippet
         await commands.executeCommand("editor.action.insertSnippet", {
           snippet: [
             ...(insertTopPaddingLine ? [""] : []),
-            "```{${1|" + languages.join(",") + "|}}",
+            header,
             "${TM_SELECTED_TEXT}$0",
             "```"
           ].join("\n"),


### PR DESCRIPTION
Closes https://github.com/quarto-dev/quarto/issues/425

With this PR, we more aggressively use the "remembered" `language`. We now just straight up insert that `language` in the code cell rather than just putting it 1st in the order of potential languages to use. This allows us to put the user's cursor directly into the code cell when they hit the keyboard shortcut.

Note this does not apply to Visual Editor, which I guess uses a very different path.

https://github.com/user-attachments/assets/ea7f5488-c340-4c7f-af42-bce4b8777886

The downside of this approach is that it isn't easily possible to get the list of potential languages to pop back up if you need to switch languages. They are basically hard coded in this one code path that now corresponds to "we don't know what language you want, so please pick one".

There do seem to be _some_ completions that pop up inside the `{}` (see the video), so in a separate PR maybe we can hook into that completion engine to get the list of language names to pop back up?