### PR TITLE
Publish extension via GH action on GH release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@
 name: Build VS Code Extension
 
 on:
+  release:
+    types:
+      - published
   push:
     branches:
       - main
@@ -37,3 +40,34 @@ jobs:
         with:
           name: quarto-vscode-${{ github.sha }}
           path: ${{ steps.package_extension.outputs.vsixPath }}
+  
+
+  publish-extension:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'release' &&
+      github.repository_owner == 'quarto-dev'
+    needs:
+      - package-extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - run: yarn install --immutable --immutable-cache --check-cache
+      - uses: actions/download-artifact@v4
+        with:
+          name: quarto-vscode-${{ github.sha }}
+
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ${{ needs.package_extension.outputs.vsixPath }}
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          extensionFile: ${{ needs.package_extension.outputs.vsixPath }}
+          registryUrl: https://marketplace.visualstudio.com        


### PR DESCRIPTION
This PR sets up infrastructure to publish the extension to the two marketplaces (OpenVSX and the Visual Studio Marketplace) via GH action via doing a GH _release_. I'll make a few notes on the PR for us to use for discussion moving forward.