### PR TITLE
Separate and update GH actions for VS Code extension

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,15 +2,16 @@
 name: Build VS Code Extension
 
 on:
-  release:
-    types:
-      - published
   push:
     branches:
       - main
+    paths:
+      - apps/vscode 
   pull_request:
     branches:
       - main
+    paths:
+      - apps/vscode 
   workflow_dispatch:
 
 jobs:
@@ -40,31 +41,3 @@ jobs:
         with:
           name: quarto-vscode-${{ github.sha }}
           path: ${{ steps.package_extension.outputs.vsixPath }}
-  
-
-  publish-extension:
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'release' &&
-      github.repository_owner == 'quarto-dev'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: latest
-      - run: yarn install --immutable --immutable-cache --check-cache
-
-      - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          yarn: true
-          packagePath: apps/vscode
-
-      - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          registryUrl: https://marketplace.visualstudio.com
-          yarn: true
-          packagePath: apps/vscode

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,18 @@
 name: Publish VS Code Extension to Marketplaces
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      ready_to_go:
+        type: boolean
+        required: true
+        description: |
+          The changelog and version are up-to-date for the VS Code extension! 🚀
 
 jobs:
   publish-extension:
     runs-on: ubuntu-latest
+    if:  ${{ inputs.ready_to_go }}
     outputs:
       vsixPath: ${{ steps.publish_extension.outputs.vsixPath }}
     steps:
@@ -14,7 +21,6 @@ jobs:
         with:
           node-version: latest
       - run: yarn install --immutable --immutable-cache --check-cache
-
 
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,47 @@
+name: Publish VS Code Extension to Marketplaces
+
+on:
+  workflow_dispatch
+
+jobs:
+  publish-extension:
+    runs-on: ubuntu-latest
+    outputs:
+      vsixPath: ${{ steps.publish_extension.outputs.vsixPath }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - run: yarn install --immutable --immutable-cache --check-cache
+
+
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          yarn: true
+          packagePath: apps/vscode
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: publish_extension
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          yarn: true
+          packagePath: apps/vscode
+
+      - name: Get version of VS Code extension to publish
+        id: extension-version
+        uses: 'euberdeveloper/ga-project-version@main'
+        with:
+          path: apps/vscode/package.json
+    
+      - name: Publish GH release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: VSC extension - v$${{ steps.project-version.outputs.version }}
+          tag_name: v${{ steps.project-version.outputs.version }}-vsix
+          fail_on_unmatched_files: true
+          files: ${{ steps.publish_extension.outputs.vsixPath }}    


### PR DESCRIPTION
After our successful 🎉 experience today publishing the VS Code extension via GH action, we have a couple of improvements to make.

This PR separate the GH action into two separate ones:

- One that builds the `.vsix` as a way to easily get a dev version into people's hands. This GH action now will run on a push or PR to main at the path `apps/vscode` (not any push/PR to main).
- One that publishes the extension to both the Microsoft and OpenVSX marketplaces. This GH action runs on workflow dispatch (i.e. pushing the button) and will also create a GH release similar to the one [we just made](https://github.com/quarto-dev/quarto/releases). This release will also include the `.vsix`. I did not set up any auto-generation of release notes; for now, we can edit the release notes after it is published. A future improvement here would be to autogenerate these. This action should be run when the extension is totally ready to go, i.e. the changelog is up to date and the version in `package.json` has been bumped.