### PR TITLE
use custom pandoc writer to preserve raw html blocks

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.116.0 (Not yet released)
+
+- Fix issue with raw html blocks being removed from document by Visual Editor (<https://github.com/quarto-dev/quarto/issues/552>)
+
 ## 1.115.0 (Release on 20 September 2024)
 
 - Suppress background highlight on first line (<https://github.com/quarto-dev/quarto/pull/537>).

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -11,7 +11,7 @@
     "pandoc",
     "quarto"
   ],
-  "version": "1.115.0",
+  "version": "1.116.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode"

--- a/packages/editor-server/src/resources/md-writer.lua
+++ b/packages/editor-server/src/resources/md-writer.lua
@@ -1,0 +1,23 @@
+---@diagnostic disable: undefined-global
+---
+--- Writer for markdown that preserves raw html attributes.
+--- 
+--- This changed in pandoc 3.2, see https://github.com/rstudio/rstudio/issues/15189.
+
+local html_formats = pandoc.List{'html', 'html4', 'html5'}
+function Writer (doc, opts)
+  if opts.extensions:includes 'raw_attribute' then
+    doc = doc:walk{
+      RawBlock = function (raw)
+        if html_formats:includes(raw.format) then
+          local md = pandoc.write(pandoc.Pandoc(raw), 'markdown-raw_html')
+          return pandoc.RawBlock('markdown', md)
+        end
+      end
+    }
+  end
+  return pandoc.write(doc, {format = 'markdown', extensions = opts.extensions}, opts)
+end
+
+Extensions = pandoc.format.extensions 'markdown'
+Template = pandoc.template.default 'markdown'


### PR DESCRIPTION
Fixes #552

Uses a custom pandoc writer to preserve raw HTML blocks (```{=html}```) when using Visual Editor.

This was due to a Pandoc 3.2+ change that was stripping these blocks when we were converting from the AST to markdown.

Note/question: I updated the CHANGELOG and extension version as part of this; not sure if that's appropriate or should be done separately.

The same change will be made separately in RStudio; it will consume this same `md-writer.lua` script (rstudio pulls in this repo to obtain panmirror so can grab it from there) and `rsession` will make the same substitution that is happening here.