### PR TITLE
add md-writer.lua from main for use by RStudio Cranberry-Hibiscus

### DIFF
--- a/packages/editor-server/src/resources/md-writer.lua
+++ b/packages/editor-server/src/resources/md-writer.lua
@@ -1,0 +1,23 @@
+---@diagnostic disable: undefined-global
+---
+--- Writer for markdown that preserves raw html attributes.
+--- 
+--- This changed in pandoc 3.2, see https://github.com/rstudio/rstudio/issues/15189.
+
+local html_formats = pandoc.List{'html', 'html4', 'html5'}
+function Writer (doc, opts)
+  if opts.extensions:includes 'raw_attribute' then
+    doc = doc:walk{
+      RawBlock = function (raw)
+        if html_formats:includes(raw.format) then
+          local md = pandoc.write(pandoc.Pandoc(raw), 'markdown-raw_html')
+          return pandoc.RawBlock('markdown', md)
+        end
+      end
+    }
+  end
+  return pandoc.write(doc, {format = 'markdown', extensions = opts.extensions}, opts)
+end
+
+Extensions = pandoc.format.extensions 'markdown'
+Template = pandoc.template.default 'markdown'


### PR DESCRIPTION
Add file from `main` to the branch used for panmirror by the RStudio cranberry-hibiscus (2024.09) release.

This is to enable fixing https://github.com/rstudio/rstudio/issues/15189 in RStudio.
