### PR TITLE
Fix roundtripping of raw latex blocks

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.116.0 (Not yet released)
 
 - Fix issue with raw html blocks being removed from document by Visual Editor (<https://github.com/quarto-dev/quarto/issues/552>)
+- Fix issue with raw latex blocks being removed from document by Visual Editor (<https://github.com/quarto-dev/quarto/issues/558>)
 
 ## 1.115.0 (Release on 20 September 2024)
 

--- a/packages/editor-server/src/resources/md-writer.lua
+++ b/packages/editor-server/src/resources/md-writer.lua
@@ -1,8 +1,10 @@
 ---@diagnostic disable: undefined-global
 ---
---- Writer for markdown that preserves raw html attributes.
+--- Writer for markdown that preserves raw html and latex attributes.
 --- 
---- This changed in pandoc 3.2, see https://github.com/rstudio/rstudio/issues/15189.
+--- This changed in pandoc 3.2, see:
+---    https://github.com/quarto-dev/quarto/issues/552
+---    https://github.com/quarto-dev/quarto/issues/558
 
 local html_formats = pandoc.List{'html', 'html4', 'html5'}
 function Writer (doc, opts)
@@ -11,6 +13,9 @@ function Writer (doc, opts)
       RawBlock = function (raw)
         if html_formats:includes(raw.format) then
           local md = pandoc.write(pandoc.Pandoc(raw), 'markdown-raw_html')
+          return pandoc.RawBlock('markdown', md)
+        elseif "latex" == raw.format then
+          local md = pandoc.write(pandoc.Pandoc(raw), 'markdown-raw_tex')
           return pandoc.RawBlock('markdown', md)
         end
       end


### PR DESCRIPTION
Fixes https://github.com/quarto-dev/quarto/issues/558

Update custom pandoc writer to preserve raw latex blocks ({=latex}) when using Visual Editor.

This was due to a Pandoc 3.2+ change that stripped these blocks when we converted from the AST to markdown.

NOTE, we still don't preserve `{=tex}` fenced blocks, but that was true before the pandoc change. I tried updating the script to also preserve `{=tex}` but it didn't work, so the root cause is elsewhere.