### PR TITLE
recognize _brand.ya?ml as part of a Quarto project

### DIFF
--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -110,9 +110,9 @@ export async function activateLsp(
     middleware.provideSignatureHelp = embeddedSignatureHelpProvider(engine);
   }
   extensionHost().registerStatementRangeProvider(engine);
-    
+
   // create client options
-  const initializationOptions : LspInitializationOptions = {
+  const initializationOptions: LspInitializationOptions = {
     quartoBinPath: quartoContext.binPath
   };
   const clientOptions: LanguageClientOptions = {
@@ -122,7 +122,7 @@ export async function activateLsp(
       {
         scheme: "*",
         language: "yaml",
-        pattern: "**/_{quarto,metadata,extension}*.{yml,yaml}",
+        pattern: "**/_{brand,quarto,metadata,extension}*.{yml,yaml}",
       },
     ],
     middleware,
@@ -284,7 +284,7 @@ function embeddedGoToDefinitionProvider(engine: MarkdownEngine) {
         );
         const resolveLocation = (location: Location) => {
           if (isLanguageVirtualDoc(vdoc.language, location.uri) ||
-              location.uri.toString() === vdocUri.uri.toString()) {
+            location.uri.toString() === vdocUri.uri.toString()) {
             return new Location(
               document.uri,
               unadjustedRange(vdoc.language, location.range)
@@ -295,7 +295,7 @@ function embeddedGoToDefinitionProvider(engine: MarkdownEngine) {
         };
         const resolveLocationLink = (location: LocationLink) => {
           if (isLanguageVirtualDoc(vdoc.language, location.targetUri) ||
-              location.targetUri.toString() === vdocUri.uri.toString()) {
+            location.targetUri.toString() === vdocUri.uri.toString()) {
             const locationLink: LocationLink = {
               targetRange: unadjustedRange(vdoc.language, location.targetRange),
               originSelectionRange: location.originSelectionRange

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -64,6 +64,7 @@ import { getHover, getSignatureHelpHover } from "../core/hover";
 import { imageHover } from "../providers/hover-image";
 import { LspInitializationOptions, QuartoContext } from "quarto-core";
 import { extensionHost } from "../host";
+import semver from "semver";
 
 let client: LanguageClient;
 
@@ -115,6 +116,11 @@ export async function activateLsp(
   const initializationOptions: LspInitializationOptions = {
     quartoBinPath: quartoContext.binPath
   };
+
+  const documentSelectorPattern = semver.gte(quartoContext.version, "1.6.24") ?
+    "**/_{brand,quarto,metadata,extension}*.{yml,yaml}" :
+    "**/_{quarto,metadata,extension}*.{yml,yaml}";
+
   const clientOptions: LanguageClientOptions = {
     initializationOptions,
     documentSelector: [
@@ -122,7 +128,7 @@ export async function activateLsp(
       {
         scheme: "*",
         language: "yaml",
-        pattern: "**/_{brand,quarto,metadata,extension}*.{yml,yaml}",
+        pattern: documentSelectorPattern,
       },
     ],
     middleware,

--- a/packages/quarto-core/src/document.ts
+++ b/packages/quarto-core/src/document.ts
@@ -1,7 +1,7 @@
 /*
  * document.ts
  *
- * Copyright (C) 2023 by Posit Software, PBC
+ * Copyright (C) 2023-2024 by Posit Software, PBC
  * Copyright (c) Microsoft Corporation. All rights reserved.
  *
  * Unless you have received this program directly from Posit Software pursuant
@@ -22,50 +22,50 @@ import { makeRange } from 'quarto-core';
  * A document in the workspace.
  */
 export interface Document {
-	/**
-	 * The uri of the document, as a string.
-	 */
-	readonly uri: string;
+  /**
+   * The uri of the document, as a string.
+   */
+  readonly uri: string;
 
-	/**
-	 * The uri of the document, as a URI. 
-	 */
-	readonly $uri?: URI;
-	
-	/**
-	 * The lanugageId of the document
-	 */
-	readonly languageId : string | undefined;
+  /**
+   * The uri of the document, as a URI. 
+   */
+  readonly $uri?: URI;
 
-	/**
-	 * Version number of the document's content. 
-	 */
-	readonly version: number;
+  /**
+   * The lanugageId of the document
+   */
+  readonly languageId: string | undefined;
 
-	/**
-	 * The total number of lines in the document.
-	 */
-	readonly lineCount: number;
+  /**
+   * Version number of the document's content. 
+   */
+  readonly version: number;
 
-	/**
-	 * Get text contents of the document.
-	 * 
-	 * @param range Optional range to get the text of. If not specified, the entire document content is returned.
-	 */
-	getText(range?: Range): string;
+  /**
+   * The total number of lines in the document.
+   */
+  readonly lineCount: number;
 
-	/**
-	 * Converts an offset in the document into a {@link Position position}.
-	 */
-	positionAt(offset: number): Position;
+  /**
+   * Get text contents of the document.
+   * 
+   * @param range Optional range to get the text of. If not specified, the entire document content is returned.
+   */
+  getText(range?: Range): string;
+
+  /**
+   * Converts an offset in the document into a {@link Position position}.
+   */
+  positionAt(offset: number): Position;
 }
 
 export function getLine(doc: Document, line: number): string {
-	return doc.getText(makeRange(line, 0, line, Number.MAX_VALUE)).replace(/\r?\n$/, '');
+  return doc.getText(makeRange(line, 0, line, Number.MAX_VALUE)).replace(/\r?\n$/, '');
 }
 
 export function getDocUri(doc: Document): URI {
-	return doc.$uri ?? URI.parse(doc.uri);
+  return doc.$uri ?? URI.parse(doc.uri);
 }
 
 
@@ -100,6 +100,7 @@ export function isQuartoYaml(doc: Document) {
   return (
     doc.languageId === kYamlLanguageId &&
     (doc.uri.match(/_quarto(-.*?)?\.ya?ml$/) ||
+      doc.uri.match(/_brand\.ya?ml$/) ||
       doc.uri.match(/_metadata\.ya?ml$/) ||
       doc.uri.match(/_extension\.ya?ml$/))
   );
@@ -113,7 +114,7 @@ const kRegExYAML =
   /(^)(---[ \t]*[\r\n]+(?![ \t]*[\r\n]+)[\W\w]*?[\r\n]+(?:---|\.\.\.))([ \t]*)$/gm;
 
 export function isQuartoDocWithFormat(doc: Document | string, format: string) {
-  if (typeof(doc) !== "string") {
+  if (typeof (doc) !== "string") {
     if (isQuartoDoc(doc)) {
       doc = doc.getText();
     } else {
@@ -125,7 +126,7 @@ export function isQuartoDocWithFormat(doc: Document | string, format: string) {
     if (match) {
       const yaml = match[0];
       return (
-        !!yaml.match(new RegExp("^format:\\s+" + format + "\\s*$","gm")) ||
+        !!yaml.match(new RegExp("^format:\\s+" + format + "\\s*$", "gm")) ||
         !!yaml.match(new RegExp("^[ \\t]*" + format + ":\\s*(default)?\\s*$", "gm"))
       );
     }


### PR DESCRIPTION
This closes #483.

It requires https://github.com/quarto-dev/quarto-cli/pull/11006 to be merged for it to work.

There's also an issue we haven't had to deal with before, which is how should different versions of the extension interact with different versions of `quarto-cli`. Right now, if the extension is "too new" for the cli, `_brand.yml` will be validated as if it were `_quarto.yml` or `_metadata.yml`. Not horrible, but not ideal. I wonder if we have a mechanism for addressing this.