### PR TITLE
Fix how we generate the release name and tag name

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Publish GH release
         uses: softprops/action-gh-release@v2
         with:
-          name: VSC extension - v$${{ steps.project-version.outputs.version }}
-          tag_name: v${{ steps.project-version.outputs.version }}-vsix
+          name: VSC extension - v$${{ steps.extension-version.outputs.version }}
+          tag_name: v${{ steps.extension-version.outputs.version }}-vsix
           fail_on_unmatched_files: true
           files: ${{ steps.publish_extension.outputs.vsixPath }}    


### PR DESCRIPTION
This GH action was not quite configured correctly, so we were evaluating to `''` or something like that for the tag name and GH release name as @cscheid saw during the last release.