### PR TITLE
Provide two keybindings with ctrl for Mac

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -496,11 +496,21 @@
       },
       {
         "command": "quarto.runCurrent",
+        "mac": "ctrl+enter",
+        "when": "editorTextFocus && editorLangId == quarto && !findInputFocussed && !replaceInputFocussed"
+      },      
+      {
+        "command": "quarto.runCurrent",
         "key": "ctrl+enter",
         "mac": "cmd+enter",
         "when": "activeCustomEditorId == 'quarto.visualEditor'"
       },
       {
+        "command": "quarto.runCurrent",
+        "mac": "ctrl+enter",
+        "when": "activeCustomEditorId == 'quarto.visualEditor'"
+      },      
+      {
         "command": "quarto.runCurrentAdvance",
         "key": "shift+enter",
         "when": "editorTextFocus && editorLangId == quarto && !findInputFocussed && !replaceInputFocussed"
@@ -518,8 +528,18 @@
       },
       {
         "command": "quarto.runCurrentCell",
+        "mac": "ctrl+shift+enter",
+        "when": "editorTextFocus && editorLangId == quarto && !findInputFocussed && !replaceInputFocussed"
+      },
+      {
+        "command": "quarto.runCurrentCell",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
+        "when": "activeCustomEditorId == 'quarto.visualEditor'"
+      },
+      {
+        "command": "quarto.runCurrentCell",
+        "mac": "ctrl+shift+enter",
         "when": "activeCustomEditorId == 'quarto.visualEditor'"
       },
       {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4767

I honestly have mixed feelings about this, but we have gotten a couple of reports across our repo from users who miss this behavior from RStudio. 

- If I were to make an argument for making this change, I would say that it is unlikely to hurt because these <kbd>Ctrl</kbd> keybindings are not likely to be taken by other commands on a Mac, including in other extensions.
- If I were to make an argument _against_ this change, I would point out that in RStudio, basically all keybindings can work with either <kbd>Ctrl</kbd> or <kbd>Cmd</kbd> on a Mac. Do we want to go down the path of supporting both for Quarto, for _everything_? If it is not for everything, are we confident that these two are worth it? 
 
You can tell in https://github.com/posit-dev/positron/issues/1518#issuecomment-2127226840 I am not enthusiastic and wonder if you all as the Quarto team will want to go down this path.