### PR TITLE
Try using a unique temp file for vdocs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'apps/vscode/**' 
+      - 'apps/vscode/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,12 @@ on:
     branches:
       - main
     paths:
-      - apps/vscode 
+      - 'apps/vscode/**' 
   pull_request:
     branches:
       - main
     paths:
-      - apps/vscode 
+      - 'apps/vscode/**' 
   workflow_dispatch:
 
 jobs:

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.117.0 (unreleased)
 
+- Fix issue with temp files for LSP request virtual documents (<https://github.com/quarto-dev/quarto/pull/585>)
+
 ## 1.116.0 (Release on 2024-10-08)
 
 - Fix issue with raw html blocks being removed from document by Visual Editor (<https://github.com/quarto-dev/quarto/issues/552>)

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -53,7 +53,6 @@ import {
   virtualDocUri,
 } from "../vdoc/vdoc";
 import { activateVirtualDocEmbeddedContent } from "../vdoc/vdoc-content";
-import { deactivateVirtualDocTempFiles, isLanguageVirtualDoc } from "../vdoc/vdoc-tempfile";
 import { vdocCompletions } from "../vdoc/vdoc-completion";
 
 import {
@@ -160,8 +159,6 @@ export async function activateLsp(
 }
 
 export function deactivate(): Thenable<void> | undefined {
-  deactivateVirtualDocTempFiles();
-
   if (!client) {
     return undefined;
   }
@@ -289,8 +286,7 @@ function embeddedGoToDefinitionProvider(engine: MarkdownEngine) {
           adjustedPosition(vdoc.language, position)
         );
         const resolveLocation = (location: Location) => {
-          if (isLanguageVirtualDoc(vdoc.language, location.uri) ||
-            location.uri.toString() === vdocUri.uri.toString()) {
+          if (location.uri.toString() === vdocUri.uri.toString()) {
             return new Location(
               document.uri,
               unadjustedRange(vdoc.language, location.range)
@@ -300,8 +296,7 @@ function embeddedGoToDefinitionProvider(engine: MarkdownEngine) {
           }
         };
         const resolveLocationLink = (location: LocationLink) => {
-          if (isLanguageVirtualDoc(vdoc.language, location.targetUri) ||
-            location.targetUri.toString() === vdocUri.uri.toString()) {
+          if (location.targetUri.toString() === vdocUri.uri.toString()) {
             const locationLink: LocationLink = {
               targetRange: unadjustedRange(vdoc.language, location.targetRange),
               originSelectionRange: location.originSelectionRange
@@ -349,5 +344,3 @@ function isWithinYamlComment(doc: TextDocument, pos: Position) {
   const line = doc.lineAt(pos.line).text;
   return !!line.match(/^\s*#\s*\| /);
 }
-
-

--- a/apps/vscode/src/vdoc/vdoc-tempfile.ts
+++ b/apps/vscode/src/vdoc/vdoc-tempfile.ts
@@ -17,6 +17,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as tmp from "tmp";
+import * as uuid from "uuid";
 import {
   commands,
   Hover,
@@ -33,10 +34,10 @@ import { EmbeddedLanguage } from "./languages";
 const languageVirtualDocs = new Map<String, TextDocument>();
 
 export async function virtualDocUriFromTempFile(
-  virtualDoc: VirtualDoc, 
-  docPath: string, 
+  virtualDoc: VirtualDoc,
+  docPath: string,
   local: boolean
-) : Promise<VirtualDocUri> {
+): Promise<VirtualDocUri> {
 
   // if this is local then create it alongside the docPath and return a cleanup 
   // function to remove it when the action is completed. 
@@ -121,7 +122,9 @@ function createVirtualDocTempFile(virtualDoc: VirtualDoc) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }
-  const tmpPath = path.join(vdocTempDir, ext, ".intellisense." + ext);
+  const tmpPath = path.join(
+    vdocTempDir, ext, ".intellisense." + uuid.v4() + "." + ext
+  );
   fs.writeFileSync(tmpPath, virtualDoc.content);
 
   return tmpPath;

--- a/apps/vscode/src/vdoc/vdoc-tempfile.ts
+++ b/apps/vscode/src/vdoc/vdoc-tempfile.ts
@@ -1,7 +1,7 @@
 /*
  * vdoc-tempfile.ts
  *
- * Copyright (C) 2022 by Posit Software, PBC
+ * Copyright (C) 2022-2024 by Posit Software, PBC
  * Copyright (c) 2019 Takashi Tamura
  *
  * Unless you have received this program directly from Posit Software pursuant
@@ -28,42 +28,27 @@ import {
   WorkspaceEdit,
 } from "vscode";
 import { VirtualDoc, VirtualDocUri } from "./vdoc";
-import { EmbeddedLanguage } from "./languages";
-
-// one virtual doc per language file extension
-const languageVirtualDocs = new Map<String, TextDocument>();
 
 export async function virtualDocUriFromTempFile(
   virtualDoc: VirtualDoc,
   docPath: string,
   local: boolean
 ): Promise<VirtualDocUri> {
+  const newVirtualDocUri = (doc: TextDocument) =>
+    <VirtualDocUri>{
+      uri: doc.uri,
+      cleanup: async () => await deleteDocument(doc),
+    };
 
-  // if this is local then create it alongside the docPath and return a cleanup 
-  // function to remove it when the action is completed. 
+  // if this is local then create it alongside the docPath and return a cleanup
+  // function to remove it when the action is completed.
   if (local || virtualDoc.language.localTempFile) {
     const ext = virtualDoc.language.extension;
     const vdocPath = path.join(path.dirname(docPath), `.vdoc.${ext}`);
     fs.writeFileSync(vdocPath, virtualDoc.content);
     const vdocUri = Uri.file(vdocPath);
     const doc = await workspace.openTextDocument(vdocUri);
-    return {
-      uri: doc.uri,
-      cleanup: async () => await deleteDocument(doc)
-    };
-  }
-
-  // do we have an existing document?
-  const langVdoc = languageVirtualDocs.get(virtualDoc.language.extension);
-  if (langVdoc && !langVdoc.isClosed) {
-    if (langVdoc.getText() === virtualDoc.content) {
-      // if its content is identical to what's passed in then just return it
-      return { uri: langVdoc.uri };
-    } else {
-      // otherwise remove it (it will get recreated below)
-      await deleteDocument(langVdoc);
-      languageVirtualDocs.delete(virtualDoc.language.extension);
-    }
+    return newVirtualDocUri(doc);
   }
 
   // write the virtual doc as a temp file
@@ -72,31 +57,17 @@ export async function virtualDocUriFromTempFile(
   // open the document and save a reference to it
   const vdocUri = Uri.file(vdocTempFile);
   const doc = await workspace.openTextDocument(vdocUri);
-  languageVirtualDocs.set(virtualDoc.language.extension, doc);
 
-  // if this is the first time getting a virtual doc for this
-  // language then execute a dummy request to cause it to load
-  if (!langVdoc) {
-    await commands.executeCommand<Hover[]>(
-      "vscode.executeHoverProvider",
-      vdocUri,
-      new Position(0, 0)
-    );
-  }
+  // TODO: Reevaluate whether this is necessary. Old comment:
+  // > if this is the first time getting a virtual doc for this
+  // > language then execute a dummy request to cause it to load
+  await commands.executeCommand<Hover[]>(
+    "vscode.executeHoverProvider",
+    vdocUri,
+    new Position(0, 0)
+  );
 
-  // return the uri
-  return { uri: doc.uri };
-}
-
-// delete any vdocs left open
-export async function deactivateVirtualDocTempFiles() {
-  languageVirtualDocs.forEach(async (doc) => {
-    await deleteDocument(doc);
-  });
-}
-
-export function isLanguageVirtualDoc(langauge: EmbeddedLanguage, uri: Uri) {
-  return languageVirtualDocs.get(langauge.extension)?.uri.toString() === uri.toString();
+  return newVirtualDocUri(doc);
 }
 
 // delete a document
@@ -122,9 +93,7 @@ function createVirtualDocTempFile(virtualDoc: VirtualDoc) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }
-  const tmpPath = path.join(
-    vdocTempDir, ext, ".intellisense." + uuid.v4() + "." + ext
-  );
+  const tmpPath = path.join(vdocTempDir, ext, ".intellisense." + uuid.v4() + "." + ext);
   fs.writeFileSync(tmpPath, virtualDoc.content);
 
   return tmpPath;


### PR DESCRIPTION
_Maybe_ addresses a category of problem some users are experiencing in Positron:

- https://github.com/posit-dev/positron/issues/3792
- https://github.com/posit-dev/positron/issues/3945
- https://github.com/posit-dev/positron/discussions/4437
- https://github.com/posit-dev/positron-beta/discussions/227

No one on the team has been able to observe this problem directly but it is clearly real. @DavisVaughan came up with the hypothesis that maybe the problem is that the `vdoc` tempfiles are getting overwritten by different requests. Quoted from Slack:

> whenever an LSP feature is fired that requires a virtual doc, quarto takes the `TextDocument`, turns it into virtual doc form (with comments in place of prose and code block fences), and writes it to a temp file
> then that temp file is used by the lsp, and it is deleted on the next lsp request
> here's where i think the problem may be. every single one of these temp files for R gets the same name, `.intellisense.r`
> 
> since we are in async world here is what may be happening:
> - a hover request starts with a particular position, we make the virtual doc, `.intellisense.r` (hover), but then hit an `await` before we complete it
> - maybe some text edits happen
> - a completion request immediately fires, we start handling that. to make its virtual doc we overwrite the original one
> - we get back to the hover request after the `await`, but now the position doesn't line up with the contents of the `.intellisense.r` document
> - ark finally handles it and things blow up

This PR uses UUIDs to make a whole bunch of different tempfiles, one for each request, rather than one file that could get deleted before the request can be handled. This is maybe overkill but we can have folks get the `.vsix` to try it out.