### PR TITLE
Fix the `path` in GH action to build extension

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,12 @@ on:
     branches:
       - main
     paths:
-      - apps/vscode 
+      - 'apps/vscode/**'
   pull_request:
     branches:
       - main
     paths:
-      - apps/vscode 
+      - 'apps/vscode/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I discovered in https://github.com/quarto-dev/quarto/pull/585 that I didn't have `paths` set correctly and am pulling it out here so it can get merged sooner.