### PR TITLE
Don't minify during development

### DIFF
--- a/apps/lsp/build.ts
+++ b/apps/lsp/build.ts
@@ -30,5 +30,6 @@ runBuild({
     { from: ['../../packages/editor-server/src/resources/**'], to: './dist/resources/' },
     { from: ['../../packages/quarto-core/src/resources/**'], to: './dist/resources/' },
     { from: ['./dist/**'], to: ['../vscode/out/lsp/'] }],
+  minify: !dev,
   dev
 })

--- a/apps/vscode/build.ts
+++ b/apps/vscode/build.ts
@@ -22,5 +22,6 @@ runBuild({
   entryPoints: ['./src/main.ts'],
   outfile: './out/main.js',
   external: ['vscode'],
+  minify: !dev,
   dev
 });

--- a/apps/vscode/build.ts
+++ b/apps/vscode/build.ts
@@ -22,6 +22,5 @@ runBuild({
   entryPoints: ['./src/main.ts'],
   outfile: './out/main.js',
   external: ['vscode'],
-  minify: dev,
   dev
 });

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -21,7 +21,6 @@ export interface BuildOptions {
   outfile: string;
   assets?: Array<AssetPair>;
   bundle?: boolean;    // true
-  minify?: boolean;    // false
   format?: Format;     // cjs
   platform?: Platform; // node
   external?: string[]; // []
@@ -36,25 +35,24 @@ export async function runBuild(options: BuildOptions) {
     bundle = true,
     format = 'cjs',
     platform = 'node',
-    minify = false,
     external,
     dev = false
   } = options;
 
-  await build({ 
+  await build({
     entryPoints,
     outfile,
     bundle,
-    minify,
+    minify: !dev,
     format,
     platform,
     external,
     sourcemap: dev,
     watch: dev ? {
       onRebuild(error) {
-        if (error) 
+        if (error)
           console.error('[watch] build failed:', error)
-        else 
+        else
           console.log('[watch] build finished')
       },
     } : false,
@@ -65,9 +63,8 @@ export async function runBuild(options: BuildOptions) {
       }),
     ] : [],
   });
-   
+
   if (dev) {
     console.log("[watch] build finished, watching for changes...");
   }
 }
-

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -21,6 +21,7 @@ export interface BuildOptions {
   outfile: string;
   assets?: Array<AssetPair>;
   bundle?: boolean;    // true
+  minify?: boolean;    // false
   format?: Format;     // cjs
   platform?: Platform; // node
   external?: string[]; // []
@@ -33,6 +34,7 @@ export async function runBuild(options: BuildOptions) {
     outfile,
     assets,
     bundle = true,
+    minify = false,
     format = 'cjs',
     platform = 'node',
     external,
@@ -43,7 +45,7 @@ export async function runBuild(options: BuildOptions) {
     entryPoints,
     outfile,
     bundle,
-    minify: !dev,
+    minify,
     format,
     platform,
     external,


### PR DESCRIPTION
Working in `apps/vscode/` currently kind of sucks because the debugging experience is suboptimal. Sourcemaps don't seem to be working right, causing the Debug Variables pane to show minified names, not real names. Stepping is also pretty jumpy.

Turns out that we are minifying during our `dev` builds, which seems to be what is breaking things. It is also kind of weird right? We should only minify during _production_, not during development. That's also what VS Code's extension guide suggests:
https://code.visualstudio.com/api/working-with-extensions/bundling-extension#run-esbuild

And what esbuild's guide says: "Usually you minify code in production but not in development."
https://esbuild.github.io/api/#minify

Before:

(Note how the variables pane has 1 letter names, and how it jumps over the if branch, seemingly without running it)


https://github.com/user-attachments/assets/de898ddd-a5b9-4c14-b5f2-c0941c3e293e

After:


https://github.com/user-attachments/assets/59a13121-b4d9-461d-9b22-6be7ace87c4a




---

In theory both VS Code and esbuild have all the required glue to make `minify + sourcemaps` work through this `names` mapping field, but clearly something isn't working right:
https://github.com/evanw/esbuild/issues/1296
https://github.com/microsoft/vscode/issues/12066 