### PR TITLE
Help topic provider with doc

### DIFF
--- a/apps/vscode/src/core/hover.ts
+++ b/apps/vscode/src/core/hover.ts
@@ -15,17 +15,18 @@
 
 
 import { Hover, MarkdownString, MarkedString, Position, SignatureHelp, commands } from "vscode";
-import { VirtualDocUri, adjustedPosition, unadjustedRange } from "../vdoc/vdoc";
+import { adjustedPosition, unadjustedRange } from "../vdoc/vdoc";
 import { EmbeddedLanguage } from "../vdoc/languages";
+import { Uri } from "vscode";
 
 export async function getHover(
-  vdocUri: VirtualDocUri,
+  uri: Uri,
   language: EmbeddedLanguage,
   position: Position
 ) {
   const hovers = await commands.executeCommand<Hover[]>(
     "vscode.executeHoverProvider",
-    vdocUri.uri,
+    uri,
     adjustedPosition(language, position)
   );
   if (hovers && hovers.length > 0) {
@@ -45,14 +46,14 @@ export async function getHover(
 }
 
 export async function getSignatureHelpHover(
-  vdocUri: VirtualDocUri,
+  uri: Uri,
   language: EmbeddedLanguage,
   position: Position,
   triggerCharacter?: string
 ) {
   return await commands.executeCommand<SignatureHelp>(
     "vscode.executeSignatureHelpProvider",
-    vdocUri.uri,
+    uri,
     adjustedPosition(language, position),
     triggerCharacter
   );

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -227,7 +227,7 @@ function embeddedHoverProvider(engine: MarkdownEngine) {
 
       // execute hover
       try {
-        return getHover(vdocUri, vdoc.language, position);
+        return getHover(vdocUri.uri, vdoc.language, position);
       } catch (error) {
         console.log(error);
       } finally {
@@ -254,7 +254,7 @@ function embeddedSignatureHelpProvider(engine: MarkdownEngine) {
     if (vdoc) {
       const vdocUri = await virtualDocUri(vdoc, document.uri, "signature");
       try {
-        return getSignatureHelpHover(vdocUri, vdoc.language, position, context.triggerCharacter);
+        return getSignatureHelpHover(vdocUri.uri, vdoc.language, position, context.triggerCharacter);
       } catch (error) {
         return undefined;
       } finally {

--- a/apps/vscode/src/providers/assist/render-assist.ts
+++ b/apps/vscode/src/providers/assist/render-assist.ts
@@ -110,13 +110,13 @@ export async function renderCodeViewAssist(
     const language = embeddedLanguage(context.language);
     if (language) {
       const vdoc = virtualDocForCode(context.code, language);
-      const vdocUri = await virtualDocUri(vdoc, Uri.file(context.filepath), "hover");
-      return await withVirtualDocUri<Assist | undefined>(vdocUri, async () => {
+      const parentUri = Uri.file(context.filepath);
+      return await withVirtualDocUri<Assist | undefined>(vdoc, parentUri, "hover", async (uri: Uri) => {
         try {
           const position = new Position(context.selection.start.line, context.selection.start.character);
 
           // check for hover
-          const hover = await getHover(vdocUri, language, position);
+          const hover = await getHover(uri, language, position);
           if (hover) {
             const assist = getAssistFromHovers([hover], asWebviewUri);
             if (assist) {
@@ -129,7 +129,7 @@ export async function renderCodeViewAssist(
           }
 
           // check for signature tip
-          const signatureHover = await getSignatureHelpHover(vdocUri, language, position);
+          const signatureHover = await getSignatureHelpHover(uri, language, position);
           if (signatureHover) {
             return getAssistFromSignatureHelp(signatureHover);
           }

--- a/apps/vscode/src/providers/format.ts
+++ b/apps/vscode/src/providers/format.ts
@@ -178,8 +178,7 @@ async function executeFormatDocumentProvider(
   document: TextDocument,
   options: FormattingOptions
 ): Promise<TextEdit[] | undefined> {
-  const vdocUri = await virtualDocUri(vdoc, document.uri, "format");
-  const edits = await withVirtualDocUri(vdocUri, async (uri: Uri) => {
+  const edits = await withVirtualDocUri(vdoc, document.uri, "format", async (uri: Uri) => {
     return await commands.executeCommand<TextEdit[]>(
       "vscode.executeFormatDocumentProvider",
       uri,

--- a/apps/vscode/src/vdoc/vdoc-completion.ts
+++ b/apps/vscode/src/vdoc/vdoc-completion.ts
@@ -24,10 +24,7 @@ export async function vdocCompletions(
   language: EmbeddedLanguage,
   parentUri: Uri
 ) {
-
-  const vdocUri = await virtualDocUri(vdoc, parentUri, "completion");
-
-  const completions = await withVirtualDocUri(vdocUri, async (uri: Uri) => {
+  const completions = await withVirtualDocUri(vdoc, parentUri, "completion", async (uri: Uri) => {
     return await commands.executeCommand<CompletionList>(
       "vscode.executeCompletionItemProvider",
       uri,

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -122,12 +122,19 @@ export type VirtualDocAction =
 
 export type VirtualDocUri = { uri: Uri, cleanup?: () => Promise<void> };
 
-export async function withVirtualDocUri<T>(virtualDocUri: VirtualDocUri, f: (uri: Uri) => Promise<T>) {
+export async function withVirtualDocUri<T>(
+  vdoc: VirtualDoc,
+  parentUri: Uri,
+  action: VirtualDocAction,
+  f: (uri: Uri) => Promise<T>
+) {
+  const vdocUri = await virtualDocUri(vdoc, parentUri, action);
+
   try {
-    return await f(virtualDocUri.uri);
+    return await f(vdocUri.uri);
   } finally {
-    if (virtualDocUri.cleanup) {
-      virtualDocUri.cleanup();
+    if (vdocUri.cleanup) {
+      vdocUri.cleanup();
     }
   }
 }


### PR DESCRIPTION
Branched from https://github.com/quarto-dev/quarto/pull/599

@juliasilge what do you think about this?

`withVirtualDocUri()` is now in charge of _both_:
- Creation of the vdocUri by calling `virtualDocUri()`
- Clean up of the vdocUri

This prevents any kind of leakage of temp files from occurring. 

After this we should try and go back and use `withVirtualDocUri()` instead of `virtualDocUri()` everywhere and then make `virtualDocUri()` private.

`withVirtualDocUri()` could also provide an error hook if a user needs to control the `} catch (error) {` case too, but I'd only add that later on if it turns out we need it.