### PR TITLE
Add C# cell executor support in VSCode

### DIFF
--- a/apps/vscode/src/host/executors.ts
+++ b/apps/vscode/src/host/executors.ts
@@ -126,6 +126,25 @@ const juliaCellExecutor: VSCodeCellExecutor = {
   },
 };
 
+const csharpCellExecutor: VSCodeCellExecutor = {
+  language: "csharp",
+  requiredExtension: ["ms-dotnettools.dotnet-interactive-vscode"],
+  requiredExtensionName: "Polyglot Notebooks",
+  requiredVersion: "1.0.55", // Adjust minimum version as needed
+  execute: async (blocks: string[], editorUri?: Uri) => {
+    const extension = extensions.getExtension("ms-dotnettools.dotnet-interactive-vscode");
+    if (extension) {
+      if (!extension.isActive) {
+        await extension.activate();
+      }
+
+      await jupyterCellExecutor("csharp").execute(blocks);
+    } else {
+      window.showErrorMessage("Unable to execute code - Polyglot Notebooks extension not found");
+    }
+  }
+};
+
 const bashCellExecutor: VSCodeCellExecutor = {
   language: "bash",
   execute: async (blocks: string[]) => {
@@ -147,6 +166,7 @@ const kCellExecutors = [
   bashCellExecutor,
   shCellExecutor,
   shellCellExecutor,
+  csharpCellExecutor
 ];
 
 function findExecutor(

--- a/apps/vscode/src/host/hooks.ts
+++ b/apps/vscode/src/host/hooks.ts
@@ -55,6 +55,7 @@ export function hooksExtensionHost(): ExtensionHost {
       switch (language) {
         // use hooks for known runtimes
         case "python":
+        case "csharp":
         case "r":
           return {
             execute: async (blocks: string[], _editorUri?: vscode.Uri): Promise<void> => {


### PR DESCRIPTION
Add C# cell executor support in VSCode similar to Python and R

<img width="850" alt="image" src="https://github.com/user-attachments/assets/20299666-e567-4678-baef-63ee40f28278">
