### PR TITLE
expose context for cell language

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.118.0 (unreleased)
 
 - Provide F1 help at cursor in Positron (<https://github.com/quarto-dev/quarto/pull/599>)
+- Expose new context keys for the language of a specific cell (<https://github.com/quarto-dev/quarto/pull/607>)
 
 ## 1.117.0 (Release on 2024-11-07)
 

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -159,10 +159,10 @@ export function languageAtPosition(tokens: Token[], position: Position) {
   if (block) {
     const language = languageFromBlock(block);
     // expose cell language for use in keybindings, etc
-    commands.executeCommand('setContext', 'quarto.cellLang', language?.extension);
+    commands.executeCommand('setContext', 'quarto.cellLangId', language?.ids[0]);
     return language;
   } else {
-    commands.executeCommand('setContext', 'quarto.cellLang', undefined);
+    commands.executeCommand('setContext', 'quarto.cellLangId', undefined);
     return undefined;
   }
 }

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { Position, TextDocument, Uri, Range } from "vscode";
+import { Position, TextDocument, Uri, Range, commands } from "vscode";
 import { Token, isExecutableLanguageBlock, languageBlockAtPosition, languageNameFromBlock } from "quarto-core";
 
 import { isQuartoDoc } from "../core/doc";
@@ -157,8 +157,12 @@ export async function virtualDocUri(
 export function languageAtPosition(tokens: Token[], position: Position) {
   const block = languageBlockAtPosition(tokens, position);
   if (block) {
-    return languageFromBlock(block);
+    const language = languageFromBlock(block);
+    // expose cell language for use in keybindings, etc
+    commands.executeCommand('setContext', 'quarto.cellLang', language?.extension);
+    return language;
   } else {
+    commands.executeCommand('setContext', 'quarto.cellLang', undefined);
     return undefined;
   }
 }


### PR DESCRIPTION
## Notes

This will update the exposed language depending on what language chunk the user's cursor is in. It will expose the language extension (eg. py, r, jl) used to run the chunk. 

The language at position does not immediately change when a cursor is placed, you have to delete or type something non-whitespace for the cell language to update. I still think this is the right place; BUT there is an alternative location where we would get feedback immediately with the language of the virtual doc, rather than the chunk. For reticulate documents, that means you'll never have Python exposed, only R.

## Trying it out

I've been testing by creating a file something like:

````markdown
---
title: new title
editor: source
---


```{r}

```


```{python}

```

````

and adding these keybindings via Command Palette -> `Preferences: Open Keyboard Shortcuts (JSON)`:


```
// Place your key bindings in this file to override the defaults
[
    {
        "key": "cmd+shift+a",
        "command": "type",
        "args": { "text": "Hello PYTHON" },
        "when": "quarto.cellLang == 'py'"
      },
      {"key": "cmd+shift+a",
      "command": "type",
      "args": { "text": "Hello RLANG" },
      "when": "quarto.cellLang == 'r'"
    },
    {"key": "cmd+shift+a",
    "command": "type",
    "args": { "text": "Hello QUARTO" },
    "when": "quarto.cellLang == ''"
  },
]
```

Then I'll go into each chunk, start typing, then do `command+shift+a`. 