### PR TITLE
Set context keys for document language

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.118.0 (unreleased)
 
 - Provide F1 help at cursor in Positron (<https://github.com/quarto-dev/quarto/pull/599>)
-- Expose new context keys for the language of a specific cell (<https://github.com/quarto-dev/quarto/pull/607>)
+- Expose new context keys for the main language of a document (<https://github.com/quarto-dev/quarto/pull/608>)
 
 ## 1.117.0 (Release on 2024-11-07)
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -23,6 +23,7 @@ import { activateDiagram } from "./providers/diagram/diagram";
 import { activateOptionEnterProvider } from "./providers/option";
 import { textFormattingCommands } from "./providers/text-format";
 import { activateCodeFormatting } from "./providers/format";
+import { activateContextKeySetter } from "./providers/context-keys";
 import { ExtensionHost } from "./host";
 
 export function activateCommon(
@@ -36,6 +37,9 @@ export function activateCommon(
 
   // background highlighter
   activateBackgroundHighlighter(context, engine);
+
+  // context setter
+  activateContextKeySetter(context, engine);
 
   // diagramming
   const diagramCommands = activateDiagram(context, host, engine);

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -22,6 +22,7 @@ import { isQuartoDoc, kQuartoDocSelector } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
 import { isExecutableLanguageBlock } from "quarto-core";
 import { vscRange } from "../core/range";
+import { mainLanguage } from "../vdoc/vdoc";
 
 export function activateBackgroundHighlighter(
   context: vscode.ExtensionContext,
@@ -161,6 +162,10 @@ async function setEditorHighlightDecorations(
     for (const block of tokens.filter(isExecutableLanguageBlock)) {
       blockRanges.push(vscRange(block.range));
     }
+
+    // expose cell language for use in keybindings, etc
+    const language = mainLanguage(tokens);
+    vscode.commands.executeCommand('setContext', 'quartoLangId', language?.ids[0]);
 
     // find inline executable code
     for (let i = 0; i < editor.document.lineCount; i++) {

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -22,7 +22,6 @@ import { isQuartoDoc, kQuartoDocSelector } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
 import { isExecutableLanguageBlock } from "quarto-core";
 import { vscRange } from "../core/range";
-import { mainLanguage } from "../vdoc/vdoc";
 
 export function activateBackgroundHighlighter(
   context: vscode.ExtensionContext,
@@ -162,10 +161,6 @@ async function setEditorHighlightDecorations(
     for (const block of tokens.filter(isExecutableLanguageBlock)) {
       blockRanges.push(vscRange(block.range));
     }
-
-    // expose cell language for use in keybindings, etc
-    const language = mainLanguage(tokens);
-    vscode.commands.executeCommand('setContext', 'quartoLangId', language?.ids[0]);
 
     // find inline executable code
     for (let i = 0; i < editor.document.lineCount; i++) {

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -1,0 +1,93 @@
+/*
+ * context-keys.ts
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+
+import * as vscode from "vscode";
+import debounce from "lodash.debounce";
+
+import { isQuartoDoc } from "../core/doc";
+import { MarkdownEngine } from "../markdown/engine";
+import { mainLanguage } from "../vdoc/vdoc";
+
+const debounceOnDidChangeDocumentMs = 250;
+
+export function activateContextKeySetter(
+  context: vscode.ExtensionContext,
+  engine: MarkdownEngine
+) {
+
+  // set context keys when docs are opened
+  vscode.workspace.onDidOpenTextDocument(
+    (doc) => {
+      if (doc === vscode.window.activeTextEditor?.document) {
+        if (isQuartoDoc(doc)) {
+          setContextKeys(vscode.window.activeTextEditor, engine);
+        }
+      }
+    },
+    null,
+    context.subscriptions
+  );
+
+  // set context keys when visible text editors change
+  vscode.window.onDidChangeVisibleTextEditors(
+    (_editors) => {
+      triggerUpdateContextKeys(engine);
+    },
+    null,
+    context.subscriptions
+  );
+
+  // set context keys on changes to the document (if its visible)
+  vscode.workspace.onDidChangeTextDocument(
+    (event) => {
+      const visibleEditor = vscode.window.visibleTextEditors.find(editor => {
+        return editor.document.uri.toString() === event.document.uri.toString();
+      });
+      if (visibleEditor) {
+        debounce(
+          () => setContextKeys(visibleEditor, engine),
+          debounceOnDidChangeDocumentMs
+        )();
+      }
+    },
+    null,
+    context.subscriptions
+  );
+
+  // set context keys at activation time
+  triggerUpdateContextKeys(engine);
+
+}
+
+function triggerUpdateContextKeys(engine: MarkdownEngine) {
+  for (const editor of vscode.window.visibleTextEditors) {
+    setContextKeys(editor, engine);
+  }
+}
+
+function setContextKeys(editor: vscode.TextEditor, engine: MarkdownEngine) {
+  if (!editor || !isQuartoDoc(editor.document)) {
+    return;
+  }
+
+  // expose main language for use in keybindings, etc
+  const tokens = engine.parse(editor.document);
+  const language = mainLanguage(tokens);
+  vscode.commands.executeCommand(
+    'setContext',
+    'quarto.document.languageId',
+    language?.ids[0]);
+}

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -27,19 +27,6 @@ export function activateContextKeySetter(
   engine: MarkdownEngine
 ) {
 
-  // set context keys when docs are opened
-  vscode.workspace.onDidOpenTextDocument(
-    (doc) => {
-      if (doc === vscode.window.activeTextEditor?.document) {
-        if (isQuartoDoc(doc)) {
-          setContextKeys(vscode.window.activeTextEditor, engine);
-        }
-      }
-    },
-    null,
-    context.subscriptions
-  );
-
   // set context keys when active text editor changes
   vscode.window.onDidChangeActiveTextEditor(
     (editor) => {

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -13,7 +13,6 @@
  *
  */
 
-
 import * as vscode from "vscode";
 import debounce from "lodash.debounce";
 
@@ -41,24 +40,24 @@ export function activateContextKeySetter(
     context.subscriptions
   );
 
-  // set context keys when visible text editors change
-  vscode.window.onDidChangeVisibleTextEditors(
-    (_editors) => {
-      triggerUpdateContextKeys(engine);
+  // set context keys when active text editor changes
+  vscode.window.onDidChangeActiveTextEditor(
+    (editor) => {
+      if (editor) {
+        setContextKeys(editor, engine);
+      }
     },
     null,
     context.subscriptions
   );
 
-  // set context keys on changes to the document (if its visible)
+  // set context keys on changes to the document (if it's active)
   vscode.workspace.onDidChangeTextDocument(
     (event) => {
-      const visibleEditor = vscode.window.visibleTextEditors.find(editor => {
-        return editor.document.uri.toString() === event.document.uri.toString();
-      });
-      if (visibleEditor) {
+      const activeEditor = vscode.window.activeTextEditor;
+      if (activeEditor) {
         debounce(
-          () => setContextKeys(visibleEditor, engine),
+          () => setContextKeys(activeEditor, engine),
           debounceOnDidChangeDocumentMs
         )();
       }
@@ -66,16 +65,6 @@ export function activateContextKeySetter(
     null,
     context.subscriptions
   );
-
-  // set context keys at activation time
-  triggerUpdateContextKeys(engine);
-
-}
-
-function triggerUpdateContextKeys(engine: MarkdownEngine) {
-  for (const editor of vscode.window.visibleTextEditors) {
-    setContextKeys(editor, engine);
-  }
 }
 
 function setContextKeys(editor: vscode.TextEditor, engine: MarkdownEngine) {

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { Position, TextDocument, Uri, Range, commands } from "vscode";
+import { Position, TextDocument, Uri, Range } from "vscode";
 import { Token, isExecutableLanguageBlock, languageBlockAtPosition, languageNameFromBlock } from "quarto-core";
 
 import { isQuartoDoc } from "../core/doc";
@@ -157,12 +157,8 @@ export async function virtualDocUri(
 export function languageAtPosition(tokens: Token[], position: Position) {
   const block = languageBlockAtPosition(tokens, position);
   if (block) {
-    const language = languageFromBlock(block);
-    // expose cell language for use in keybindings, etc
-    commands.executeCommand('setContext', 'quarto.cellLangId', language?.ids[0]);
-    return language;
+    return languageFromBlock(block);
   } else {
-    commands.executeCommand('setContext', 'quarto.cellLangId', undefined);
     return undefined;
   }
 }


### PR DESCRIPTION
This is a revamp of the work in #607.

Unfortunately after I started trying to use this in Positron, it just wasn't early enough or quick enough to set these context keys in `languageAtPosition()`. I believe that only gets called if we are trying to do one of these:

https://github.com/quarto-dev/quarto/blob/d9d15151187cd2222b0ce47e1654f3a92031b177/apps/vscode/src/vdoc/vdoc.ts#L114-L121

It's just not enough, especially if you are switching back and forth between different files; it's very easy to get in a state where you end up with R shortcuts in Python chunks and there are lots of kinds of edits I could make that did not trigger one of these.

New idea! This PR tries out setting these context keys when we paint the background. In my experience so far, this feels a lot better, and we already are identifying all the `tokens` so not much extra work.