### PR TITLE
Do not force snippet suggestions to the bottom of completions

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Provide F1 help at cursor in Positron (<https://github.com/quarto-dev/quarto/pull/599>)
 - Expose new context keys for the language of a specific cell (<https://github.com/quarto-dev/quarto/pull/607>)
+- No longer send all snippet suggestions to the bottom of the completion list (<https://github.com/quarto-dev/quarto/pull/609>).
 
 ## 1.117.0 (Release on 2024-11-07)
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -896,7 +896,6 @@
           "strings": "on"
         },
         "editor.quickSuggestionsDelay": 250,
-        "editor.snippetSuggestions": "bottom",
         "editor.wordBasedSuggestions": "off",
         "editor.suggestOnTriggerCharacters": true,
         "editor.unicodeHighlight.ambiguousCharacters": false,


### PR DESCRIPTION
Currently, we force snippet suggestions to the bottom of the completions list:

https://github.com/quarto-dev/quarto/blob/d818dd022d803ea93db34d1a6ccca56a05d54348/apps/vscode/package.json#L899

If we don't force this, then they will go wherever the underlying `embeddedCodeCompletionProvider` wants them to go. I'll install the new `.vsix` in VS Code and Positron to show where snippets show up with this proposed change.