### PR TITLE
fix: Use text area for alternative text input in image editor

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.119.0 (unreleased)
 
+- Visual Editor: "Inset image" command now uses a text box for the alternative text. (<https://github.com/quarto-dev/quarto/pull/599>)
+
 ## 1.118.0 (Release on 2024-11-26)
 
 - Provide F1 help at cursor in Positron (<https://github.com/quarto-dev/quarto/pull/599>)

--- a/packages/editor-ui/src/dialogs/edit-image.tsx
+++ b/packages/editor-ui/src/dialogs/edit-image.tsx
@@ -28,7 +28,8 @@ import {
   useId, 
   RadioGroup, 
   Label, 
-  Radio 
+  Radio,
+  Textarea
 } from "@fluentui/react-components";
 
 import { ModalDialog, ModalDialogTabList, showValueEditorDialog} from "ui-widgets";
@@ -162,10 +163,11 @@ const imagePanel =
   
     {alt !== undefined
       ?  <Field label={t("Alternative text")}>
-          <Input 
-            value={alt} 
+          <Textarea
+            value={alt}
             onChange={(_ev, data) => setAlt(data.value)}
             placeholder={t("(Optional)")}
+            style={{ height: "100px" }}
           />
         </Field>
       : null
@@ -288,6 +290,3 @@ const useStyles = makeStyles({
     gridRowGap: tokens.spacingVerticalS,
   }
 })
-
-
-


### PR DESCRIPTION
Replace the input field with a text area for entering alternative text in the image editing dialog, enhancing user experience.