### PR TITLE
fix: Ensure `#|` is added only at the beginning of a new line

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.119.0 (unreleased)
 
+- Ensure `#|` is added only at the beginning of a new line (<https://github.com/quarto-dev/quarto/pull/649>).
+
 ## 1.118.0 (Release on 2024-11-26)
 
 - Provide F1 help at cursor in Positron (<https://github.com/quarto-dev/quarto/pull/599>)

--- a/apps/vscode/src/providers/option.ts
+++ b/apps/vscode/src/providers/option.ts
@@ -84,7 +84,7 @@ function handleOptionEnter(editor: TextEditor, comment: string) {
     });
   } else if (currentLine.startsWith(optionComment)) {
     editor.edit((builder) => {
-      builder.insert(editor.selection.start.translate(1, 0), optionComment);
+      builder.insert(editor.selection.start.translate(1, -editor.selection.active.character), optionComment);
     });
   }
 }


### PR DESCRIPTION
Adjust the insertion logic to guarantee that `#|` is added at the start of a new line, addressing issues with code formatting on return. Fixes #426

Proposed behaviour:



https://github.com/user-attachments/assets/d3a58d6d-c2ce-4999-b028-b130f91b278e

