### PR TITLE
fix: `language` typos throughout the codebase

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.119.0 (unreleased)
 
+- Fix `language` typos throughout the codebase (<https://github.com/quarto-dev/quarto/pull/650>)
+
 ## 1.118.0 (Release on 2024-11-26)
 
 - Provide F1 help at cursor in Positron (<https://github.com/quarto-dev/quarto/pull/599>)

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -178,7 +178,7 @@ function embeddedCodeCompletionProvider(engine: MarkdownEngine) {
     const vdoc = await virtualDoc(document, position, engine);
 
     if (vdoc && !isWithinYamlComment(document, position)) {
-      // if there is a trigger character make sure the langauge supports it
+      // if there is a trigger character make sure the language supports it
       const language = vdoc.language;
       if (context.triggerCharacter) {
         if (

--- a/apps/vscode/src/providers/cell/commands.ts
+++ b/apps/vscode/src/providers/cell/commands.ts
@@ -521,7 +521,7 @@ class RunCellsBelowCommand extends RunCommand implements Command {
     for (const blk of tokens.filter((token?: Token) => blockIsExecutable(this.host_, token)) as Array<TokenMath | TokenCodeBlock>) {
       // skip if the cell is above or at the cursor
       if (line < blk.range.start.line) {
-        // set langauge if needed
+        // set language if needed
         const blockLanguage = languageNameFromBlock(blk);
         if (!language) {
           language = blockLanguage;

--- a/apps/vscode/src/providers/option.ts
+++ b/apps/vscode/src/providers/option.ts
@@ -52,7 +52,7 @@ export function activateOptionEnterProvider(
               );
               if (block) {
                 const language = languageNameFromBlock(block);
-                // handle option enter for the this langauge if we can
+                // handle option enter for the this language if we can
                 const optionComment = languageOptionComment(language);
                 if (optionComment) {
                   handleOptionEnter(window.activeTextEditor, optionComment);
@@ -89,14 +89,14 @@ function handleOptionEnter(editor: TextEditor, comment: string) {
   }
 }
 
-function languageOptionComment(langauge: string) {
+function languageOptionComment(language: string) {
   // some mappings
-  if (langauge === "ojs") {
-    langauge = "js";
+  if (language === "ojs") {
+    language = "js";
   }
 
-  if (Object.keys(kLangCommentChars).includes(langauge)) {
-    return kLangCommentChars[langauge];
+  if (Object.keys(kLangCommentChars).includes(language)) {
+    return kLangCommentChars[language];
   } else {
     return undefined;
   }

--- a/apps/vscode/src/vdoc/languages.ts
+++ b/apps/vscode/src/vdoc/languages.ts
@@ -28,9 +28,9 @@ export interface EmbeddedLanguage {
   canFormatDocument?: boolean;
 }
 
-export function embeddedLanguage(langauge: string) {
-  langauge = langauge.split("-").pop() || "";
-  return kEmbededLanguages.find((lang) => lang.ids.includes(langauge));
+export function embeddedLanguage(language: string) {
+  language = language.split("-").pop() || "";
+  return kEmbededLanguages.find((lang) => lang.ids.includes(language));
 }
 
 export function languageCanFormatDocument(language: EmbeddedLanguage) {
@@ -38,7 +38,7 @@ export function languageCanFormatDocument(language: EmbeddedLanguage) {
 }
 
 const kEmbededLanguages = [
-  // these langauges required creating a temp file
+  // these languages required creating a temp file
   defineLanguage("python", {
     inject: ["# type: ignore", "# flake8: noqa"],
     emptyLine: "#",
@@ -77,7 +77,7 @@ const kEmbededLanguages = [
   defineLanguage("java"),
   defineLanguage("cpp"),
   defineLanguage("go"),
-  // these langauges work w/ text document content provider
+  // these languages work w/ text document content provider
   defineLanguage("html", { type: "content" }),
   defineLanguage("css", { type: "content" }),
   defineLanguage("javascript", { type: "content" }),
@@ -98,7 +98,7 @@ function defineLanguage(
   options?: LanguageOptions
 ): EmbeddedLanguage {
 
-  // lookup langauge
+  // lookup language
   const language = editorLanguage(id);
   if (!language) {
     throw new Error(`Unknown language ${id}`);


### PR DESCRIPTION
Correct multiple instances of the misspelled word `langauge` to `language` for consistency and clarity.