### PR TITLE
feat: allow to skip modal prompt in CI/test environment

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.119.0 (unreleased)
 
-- Use `CI` to bypass the Visual Editor confirmation dialogue (<https://github.com/quarto-dev/quarto/pull/654>).
+- Use `CI=true` or `QUARTO_VISUAL_EDITOR_CONFIRMED=true` to bypass the Visual Editor confirmation dialogue (<https://github.com/quarto-dev/quarto/pull/654>).
 
 ## 1.118.0 (Release on 2024-11-26)
 

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.119.0 (unreleased)
 
-- Use `CI` to bypass the Visual Editor confirmation dialogue.
+- Use `CI` to bypass the Visual Editor confirmation dialogue (<https://github.com/quarto-dev/quarto/pull/654>).
 
 ## 1.118.0 (Release on 2024-11-26)
 

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.119.0 (unreleased)
 
+- Use `CI` to bypass the Visual Editor confirmation dialogue.
+
 ## 1.118.0 (Release on 2024-11-26)
 
 - Provide F1 help at cursor in Positron (<https://github.com/quarto-dev/quarto/pull/599>)

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.119.0 (unreleased)
 
-- Use `CI=true` or `QUARTO_VISUAL_EDITOR_CONFIRMED=true` to bypass the Visual Editor confirmation dialogue (<https://github.com/quarto-dev/quarto/pull/654>).
+- Use `QUARTO_VISUAL_EDITOR_CONFIRMED` > `PW_TEST` > `CI` to bypass (`true`) or force (`false`) the Visual Editor confirmation dialogue (<https://github.com/quarto-dev/quarto/pull/654>).
 
 ## 1.118.0 (Release on 2024-11-26)
 

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -327,7 +327,7 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
 
     // prompt the user
     const kVisualModeConfirmed = "visualModeConfirmed";
-    if (process.env.CI === "true") {
+    if (process.env.CI === "true" || process.env.QUARTO_VISUAL_EDITOR_CONFIRMED === "true") {
       this.context.globalState.update(kVisualModeConfirmed, true);
     }
     if (this.context.globalState.get(kVisualModeConfirmed) !== true) {

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -336,9 +336,7 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
       "QUARTO_VISUAL_EDITOR_CONFIRMED"
     ];
     envVars.forEach(envVar => {
-      console.log(`Checking for environment variable: ${envVar}`);
       if (process.env[envVar] !== undefined) {
-        console.log(`Setting visual mode confirmation to ${process.env[envVar] === "true"}`);
         this.context.globalState.update(kVisualModeConfirmed, process.env[envVar] === "true");
       }
     });

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -327,6 +327,9 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
 
     // prompt the user
     const kVisualModeConfirmed = "visualModeConfirmed";
+    if (process.env.CI === "true") {
+      this.context.globalState.update(kVisualModeConfirmed, true);
+    }
     if (this.context.globalState.get(kVisualModeConfirmed) !== true) {
       const kUseVisualMode = "Use Visual Mode";
       const kLearnMore = "Learn More...";

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -327,9 +327,22 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
 
     // prompt the user
     const kVisualModeConfirmed = "visualModeConfirmed";
-    if (process.env.CI === "true" || process.env.QUARTO_VISUAL_EDITOR_CONFIRMED === "true") {
-      this.context.globalState.update(kVisualModeConfirmed, true);
-    }
+
+    // Check for environment variables to force the state of the visual editor confirmation modal
+    // QUARTO_VISUAL_EDITOR_CONFIRMED > PW_TEST > CI
+    const envVars = [
+      "CI",
+      "PW_TEST",
+      "QUARTO_VISUAL_EDITOR_CONFIRMED"
+    ];
+    envVars.forEach(envVar => {
+      console.log(`Checking for environment variable: ${envVar}`);
+      if (process.env[envVar] !== undefined) {
+        console.log(`Setting visual mode confirmation to ${process.env[envVar] === "true"}`);
+        this.context.globalState.update(kVisualModeConfirmed, process.env[envVar] === "true");
+      }
+    });
+
     if (this.context.globalState.get(kVisualModeConfirmed) !== true) {
       const kUseVisualMode = "Use Visual Mode";
       const kLearnMore = "Learn More...";


### PR DESCRIPTION
In a CI/test environment, the modal prompt for visual mode confirmation is automatically confirmed, streamlining the process.

For reference:
- https://github.com/posit-dev/positron/pull/6251

The following precedence logic is implemented:
- QUARTO_VISUAL_EDITOR_CONFIRMED > PW_TEST > CI