### PR TITLE
Add `allowIncomplete` to `runtime.executeCode()`

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.119.0 (unreleased)
 
 - Use `QUARTO_VISUAL_EDITOR_CONFIRMED` > `PW_TEST` > `CI` to bypass (`true`) or force (`false`) the Visual Editor confirmation dialogue (<https://github.com/quarto-dev/quarto/pull/654>).
+- Fix behavior in Positron when running a cell containing invalid/incomplete code (<https://github.com/quarto-dev/quarto/pull/664>).
 
 ## 1.118.0 (Release on 2024-11-26)
 

--- a/apps/vscode/src/@types/hooks.d.ts
+++ b/apps/vscode/src/@types/hooks.d.ts
@@ -16,7 +16,8 @@ declare module 'positron' {
 		executeCode(
 			languageId: string,
 			code: string,
-			focus: boolean
+			focus: boolean,
+			allowIncomplete: boolean
 		): Thenable<boolean>;
 	}
 

--- a/apps/vscode/src/host/hooks.ts
+++ b/apps/vscode/src/host/hooks.ts
@@ -74,7 +74,7 @@ export function hooksExtensionHost(): ExtensionHost {
               // Our callback executes each block sequentially
               const callback = async () => {
                 for (const block of blocks) {
-                  await runtime.executeCode(language, block, false);
+                  await runtime.executeCode(language, block, false, true);
                 }
               }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4459

Before this change, if you had some invalid code in a code chunk (R or Python) such as this:

````
```{r}
rnorm(1000, 1. 2)
```
````

then using "Run Cell" (either via the button or keybinding) in Positron would result in the console just looking like nothing is happening. What is happening under the hood is that Positron can tell the statement isn't "complete" and it's waiting for the user to finish it. That isn't an appropriate thing for the console to do in many situations, so we have the option `allowIncomplete`:

> Whether to bypass runtime code completeness checks. If true, the `code` will be executed by the runtime even if it is incomplete or invalid. Defaults to false.

This PR changes the Positron Quarto executors to use true, i.e. to skip the code completeness checks and just execute the code, even if it is about to error.