### PR TITLE
Add option to use theme provided cell background (#675)

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -960,8 +960,16 @@
           "default": "#40404066",
           "markdownDescription": "CSS color for background of executable code cells on dark themes.\n\n*Note that this color should include an alpha channel so that selections show up against the background.*"
         },
-        "quarto.cells.background.delay": {
-          "order": 22,
+        "quarto.cells.background.useTheme": {
+					"order": 22,
+					"scope": "window",
+					"type": "string",
+					"format": "color",
+					"default": false,
+					"markdownDescription": "Should the background of executable code cells be based on the theme provided color.\n\nThis uses the `notebook.selectedCellBackground` color from the VSCode theme."
+				},
+				"quarto.cells.background.delay": {
+					"order": 23,
           "scope": "window",
           "type": "integer",
           "default": 250,

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -213,8 +213,16 @@ class HiglightingConfig {
 
   public sync() {
     const config = vscode.workspace.getConfiguration("quarto");
-    const light = config.get("cells.background.light", "#E1E1E166");
-    const dark = config.get("cells.background.dark", "#40404066");
+    const useTheme = config.get("cells.background.useTheme", false);
+    let light, dark;
+    if (useTheme) {
+      const activeCellBackgroundThemeColor = new vscode.ThemeColor('notebook.selectedCellBackground');
+      light = activeCellBackgroundThemeColor;
+      dark = activeCellBackgroundThemeColor;
+    } else {
+      light = config.get("cells.background.light", "#E1E1E166");
+      dark = config.get("cells.background.dark", "#40404066");
+    }
 
     this.enabled_ = config.get("cells.background.enabled", true);
     this.delayMs_ = config.get("cells.background.delay", 250);


### PR DESCRIPTION
Adds option `cells.background.useTheme` that when true will use the theme's built in cell background. 

Positron Light:
![Positron Light](https://github.com/user-attachments/assets/d46c3ecd-cff9-4d62-a02b-c92a45936984)
Gruvbox Light Soft:
![Gruvbox Light Soft](https://github.com/user-attachments/assets/5c8bb8f6-28c5-4838-ae01-28f8de5c8fb2)
