### PR TITLE
Use new `positron.reopenWith` command to switch between visual/source editing

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Ensure `#|` is added only at the beginning of a new line (<https://github.com/quarto-dev/quarto/pull/649>).
 - Fix `language` typos throughout the codebase (<https://github.com/quarto-dev/quarto/pull/650>)
 - Update cell background configuration to add the ability to use the appropriate theme color. The `quarto.cells.background` settings have changed names so you may need to update your configuration (<https://github.com/quarto-dev/quarto/pull/679>).
+- Use new command to switch between source and visual editors in Positron (<https://github.com/quarto-dev/quarto/pull/684>).
 
 ## 1.118.0 (Release on 2024-11-26)
 


### PR DESCRIPTION
Related to https://github.com/posit-dev/positron/pull/6698 where we added this new command, specifically to be used in Quarto

Also related to intermittent bad behavior we see reported such as in https://github.com/quarto-dev/quarto/issues/627

We've wanted to do this for a long time, because this new approach is much safer (more like the built-in `ReOpenInTextEditorAction` that VS Code itself uses) than trying to do all that switching from the extension. See more details in https://github.com/posit-dev/positron/issues/6230.

Unfortunately, we can't remove the other code path, because this command is one we newly exposed to extensions in Positron only.