### PR TITLE
Display command titles on editor action bar in Positron

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -254,7 +254,10 @@
         "title": "Preview",
         "icon": "$(preview)",
         "category": "Quarto",
-        "displayTitleOnActionBar": true
+        "actionBarOptions": {
+          "controlType": "button",
+          "displayTitle": true
+        }
       },
       {
         "command": "quarto.previewScript",
@@ -425,6 +428,15 @@
         "title": "Toggle Code",
         "category": "Quarto",
         "enablement": "editorTextFocus && !editorReadonly && editorLangId == quarto"
+      },
+      {
+        "command": "quarto.toggleRenderOnSave",
+        "title": "Render on Save",
+        "enablement": "isPositron",
+        "actionBarOptions": {
+            "controlType": "checkbox",
+            "checked": "quarto.renderOnSave == true"
+        }
       },
       {
         "command": "quarto.zoteroConfigureLibrary",
@@ -677,6 +689,12 @@
         {
           "command": "quarto.previewContentShortcut",
           "when": "editorLangId == mermaid || editorLangId == dot"
+        }
+      ],
+      "editor/actions/right": [
+        {
+          "command": "quarto.toggleRenderOnSave",
+          "group": "navigation@101"
         }
       ],
       "notebook/toolbar": [

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -253,7 +253,8 @@
         "command": "quarto.preview",
         "title": "Preview",
         "icon": "$(preview)",
-        "category": "Quarto"
+        "category": "Quarto",
+        "displayTitleOnActionBar": true
       },
       {
         "command": "quarto.previewScript",

--- a/apps/vscode/src/providers/preview/commands.ts
+++ b/apps/vscode/src/providers/preview/commands.ts
@@ -23,7 +23,6 @@ import {
   workspace,
   commands,
   QuickPickItemKind,
-  ExtensionContext
 } from "vscode";
 import { QuartoContext, QuartoFormatInfo, quartoDocumentFormats } from "quarto-core";
 

--- a/apps/vscode/src/providers/preview/commands.ts
+++ b/apps/vscode/src/providers/preview/commands.ts
@@ -16,7 +16,15 @@
 import * as path from "path";
 import * as fs from "fs";
 
-import { TextDocument, window, Uri, workspace, commands, QuickPickItem } from "vscode";
+import {
+  TextDocument,
+  window,
+  Uri,
+  workspace,
+  commands,
+  QuickPickItemKind,
+  ExtensionContext
+} from "vscode";
 import { QuartoContext, QuartoFormatInfo, quartoDocumentFormats } from "quarto-core";
 
 import { Command } from "../../core/command";
@@ -29,18 +37,19 @@ import { canPreviewDoc, findQuartoEditor, isNotebook } from "../../core/doc";
 import { renderOnSave } from "./preview-util";
 import { documentFrontMatterYaml } from "../../markdown/document";
 import { FormatQuickPickItem, RenderCommand } from "../render";
-import { QuickPickItemKind } from "vscode";
 
 export function previewCommands(
   quartoContext: QuartoContext,
+  context: ExtensionContext,
   engine: MarkdownEngine
 ): Command[] {
   return [
-    new PreviewCommand(quartoContext, engine),
-    new PreviewScriptCommand(quartoContext, engine),
-    new PreviewFormatCommand(quartoContext, engine),
-    new WalkthroughPreviewCommand(quartoContext, engine),
+    new PreviewCommand(quartoContext, context, engine),
+    new PreviewScriptCommand(quartoContext, context, engine),
+    new PreviewFormatCommand(quartoContext, context, engine),
+    new WalkthroughPreviewCommand(quartoContext, context, engine),
     new ClearCacheCommand(quartoContext, engine),
+    new ToggleRenderOnSaveCommand(context),
   ];
 }
 const kChooseFormat = "EB451697-D09E-48F5-AA40-4DAE7E1D31B8";
@@ -49,6 +58,7 @@ const kChooseFormat = "EB451697-D09E-48F5-AA40-4DAE7E1D31B8";
 abstract class PreviewDocumentCommandBase extends RenderCommand {
   constructor(
     quartoContext: QuartoContext,
+    private readonly context_: ExtensionContext,
     private readonly engine_: MarkdownEngine
   ) {
     super(quartoContext);
@@ -56,7 +66,7 @@ abstract class PreviewDocumentCommandBase extends RenderCommand {
   protected async renderFormat(format?: string | null, onShow?: () => void) {
     const targetEditor = findQuartoEditor(this.engine_, this.quartoContext(), canPreviewDoc);
     if (targetEditor) {
-      const hasRenderOnSave = await renderOnSave(this.engine_, targetEditor.document);
+      const hasRenderOnSave = await renderOnSave(this.engine_, targetEditor.document, this.context_);
       const render =
         !hasRenderOnSave ||
         (hasRenderOnSave && format) ||
@@ -127,8 +137,8 @@ abstract class PreviewDocumentCommandBase extends RenderCommand {
 class PreviewCommand
   extends PreviewDocumentCommandBase
   implements Command {
-  constructor(quartoContext: QuartoContext, engine: MarkdownEngine) {
-    super(quartoContext, engine);
+  constructor(quartoContext: QuartoContext, context: ExtensionContext, engine: MarkdownEngine) {
+    super(quartoContext, context, engine);
   }
   private static readonly id = "quarto.preview";
   public readonly id = PreviewCommand.id;
@@ -141,8 +151,8 @@ class PreviewCommand
 class PreviewScriptCommand
   extends PreviewDocumentCommandBase
   implements Command {
-  constructor(quartoContext: QuartoContext, engine: MarkdownEngine) {
-    super(quartoContext, engine);
+  constructor(quartoContext: QuartoContext, context: ExtensionContext, engine: MarkdownEngine) {
+    super(quartoContext, context, engine);
   }
   private static readonly id = "quarto.previewScript";
   public readonly id = PreviewScriptCommand.id;
@@ -155,8 +165,8 @@ class PreviewScriptCommand
 class PreviewFormatCommand
   extends PreviewDocumentCommandBase
   implements Command {
-  constructor(quartoContext: QuartoContext, engine: MarkdownEngine) {
-    super(quartoContext, engine);
+  constructor(quartoContext: QuartoContext, context: ExtensionContext, engine: MarkdownEngine) {
+    super(quartoContext, context, engine);
   }
   private static readonly id = "quarto.previewFormat";
   public readonly id = PreviewFormatCommand.id;
@@ -237,4 +247,17 @@ function cacheDirForDocument(doc: TextDocument) {
   }
 
   return undefined;
+}
+
+class ToggleRenderOnSaveCommand implements Command {
+  constructor(private readonly context_: ExtensionContext) { }
+  private static readonly id = "quarto.toggleRenderOnSave";
+  public readonly id = ToggleRenderOnSaveCommand.id;
+
+  async execute() {
+    let renderOnSave = this.context_.workspaceState.get<boolean>('positron.quarto.toggleRenderOnSave') === true;
+    renderOnSave = !renderOnSave;
+    this.context_.workspaceState.update('positron.quarto.toggleRenderOnSave', renderOnSave);
+    commands.executeCommand<boolean>('setContext', 'quarto.renderOnSave', renderOnSave);
+  }
 }

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -16,7 +16,7 @@
 import semver from "semver";
 
 import vscode from "vscode";
-import { TextDocument, Uri, workspace } from "vscode";
+import { TextDocument, ExtensionContext, workspace } from "vscode";
 
 import {
   projectDirForDocument,
@@ -87,7 +87,7 @@ async function parseRPackageDescription(): Promise<string[]> {
   return [''];
 }
 
-export async function renderOnSave(engine: MarkdownEngine, document: TextDocument) {
+export async function renderOnSave(engine: MarkdownEngine, document: TextDocument, context: ExtensionContext) {
   // if its a notebook and we don't have a save hook for notebooks then don't
   // allow renderOnSave (b/c we can't detect the saves)
   if (isNotebook(document) && !haveNotebookSaveEvents()) {
@@ -99,7 +99,13 @@ export async function renderOnSave(engine: MarkdownEngine, document: TextDocumen
     return true;
   }
 
-  // first look for document level editor setting
+  // first look at workspace state for toggle value in Positron
+  const toggleRenderOnSave = context.workspaceState.get<boolean>('positron.quarto.toggleRenderOnSave') === true;
+  if (toggleRenderOnSave) {
+    return toggleRenderOnSave;
+  }
+
+  // next look for document level editor setting
   const docYaml = documentFrontMatter(engine, document);
   const docSetting = readRenderOnSave(docYaml);
   if (docSetting !== undefined) {

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -28,7 +28,6 @@ import { isNotebook } from "../../core/doc";
 import { MarkdownEngine } from "../../markdown/engine";
 import { documentFrontMatter } from "../../markdown/document";
 import { isKnitrDocument } from "../../host/executors";
-import { ExtensionContext } from "vscode";
 
 
 export function isQuartoShinyDoc(

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -88,7 +88,7 @@ async function parseRPackageDescription(): Promise<string[]> {
   return [''];
 }
 
-export async function renderOnSave(engine: MarkdownEngine, document: TextDocument, context: ExtensionContext) {
+export async function renderOnSave(engine: MarkdownEngine, document: TextDocument) {
   // if its a notebook and we don't have a save hook for notebooks then don't
   // allow renderOnSave (b/c we can't detect the saves)
   if (isNotebook(document) && !haveNotebookSaveEvents()) {
@@ -100,13 +100,7 @@ export async function renderOnSave(engine: MarkdownEngine, document: TextDocumen
     return true;
   }
 
-  // first look at workspace state for toggle value in Positron
-  const toggleRenderOnSave = context.workspaceState.get<boolean>('positron.quarto.toggleRenderOnSave') === true;
-  if (toggleRenderOnSave) {
-    return toggleRenderOnSave;
-  }
-
-  // next look for document level editor setting
+  // first look for document level editor setting
   const docYaml = documentFrontMatter(engine, document);
   const docSetting = readRenderOnSave(docYaml);
   if (docSetting !== undefined) {

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -28,6 +28,7 @@ import { isNotebook } from "../../core/doc";
 import { MarkdownEngine } from "../../markdown/engine";
 import { documentFrontMatter } from "../../markdown/document";
 import { isKnitrDocument } from "../../host/executors";
+import { ExtensionContext } from "vscode";
 
 
 export function isQuartoShinyDoc(
@@ -87,7 +88,7 @@ async function parseRPackageDescription(): Promise<string[]> {
   return [''];
 }
 
-export async function renderOnSave(engine: MarkdownEngine, document: TextDocument) {
+export async function renderOnSave(engine: MarkdownEngine, document: TextDocument, context: ExtensionContext) {
   // if its a notebook and we don't have a save hook for notebooks then don't
   // allow renderOnSave (b/c we can't detect the saves)
   if (isNotebook(document) && !haveNotebookSaveEvents()) {
@@ -99,7 +100,13 @@ export async function renderOnSave(engine: MarkdownEngine, document: TextDocumen
     return true;
   }
 
-  // first look for document level editor setting
+  // first look at workspace state for toggle value in Positron
+  const toggleRenderOnSave = context.workspaceState.get<boolean>('positron.quarto.toggleRenderOnSave') === true;
+  if (toggleRenderOnSave) {
+    return toggleRenderOnSave;
+  }
+
+  // next look for document level editor setting
   const docYaml = documentFrontMatter(engine, document);
   const docSetting = readRenderOnSave(docYaml);
   if (docSetting !== undefined) {

--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -112,11 +112,12 @@ export function activatePreview(
     context.subscriptions.push(previewManager);
   }
 
-  // initialize Positron toggle from setting
+  // initialize Positron toggle from setting, store in workspace storage
   if (hasHooks()) {
     const config = workspace.getConfiguration("quarto");
     const renderOnSave = config.get<boolean>("render.renderOnSave", false);
     commands.executeCommand<boolean>("setContext", "quarto.renderOnSave", renderOnSave);
+    context.workspaceState.update('positron.quarto.toggleRenderOnSave', renderOnSave);
   }
 
   // render on save
@@ -129,7 +130,7 @@ export function activatePreview(
     if (editor) {
       if (
         canPreviewDoc(editor.document) &&
-        (await renderOnSave(engine, editor.document)) &&
+        (await renderOnSave(engine, editor.document, context)) &&
         (await previewManager.isPreviewRunningForDoc(editor.document))
       ) {
         await previewDoc(editor, undefined, true, engine, quartoContext);
@@ -181,7 +182,7 @@ export function activatePreview(
   );
 
   // preview commands
-  return previewCommands(quartoContext, engine);
+  return previewCommands(quartoContext, context, engine);
 }
 
 

--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -120,7 +120,7 @@ export function activatePreview(
     if (editor) {
       if (
         canPreviewDoc(editor.document) &&
-        (await renderOnSave(engine, editor.document)) &&
+        (await renderOnSave(engine, editor.document, context)) &&
         (await previewManager.isPreviewRunningForDoc(editor.document))
       ) {
         await previewDoc(editor, undefined, true, engine, quartoContext);
@@ -172,7 +172,7 @@ export function activatePreview(
   );
 
   // preview commands
-  return previewCommands(quartoContext, engine);
+  return previewCommands(quartoContext, context, engine);
 }
 
 


### PR DESCRIPTION
Related to https://github.com/posit-dev/positron/pull/7191
Related to https://github.com/posit-dev/positron/issues/6440

I'll leave this in draft until we get some of the other controls set up as well. In VS Code, this all falls back to the basic behavior (no titles).