### PR TITLE
Feature/Positron Editor Action Bar integration for Source / Visual toggle and [X] Render on Save checkbox

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -426,6 +426,16 @@
         "enablement": "editorTextFocus && !editorReadonly && editorLangId == quarto"
       },
       {
+        "command": "quarto.toggleRenderOnSave",
+        "title": "Render on Save",
+        "category": "Quarto",
+        "enablement": "editorLangId == quarto",
+        "actionBarOptions": {
+          "controlType": "checkbox",
+          "checked": "(quarto.editor.type == quarto && quarto.editor.renderOnSave) || (quarto.editor.type == 'quarto-shiny' && quarto.editor.renderOnSaveShiny)"
+        }
+      },
+      {
         "command": "quarto.zoteroConfigureLibrary",
         "category": "Quarto",
         "title": "Zotero - Connect Web Library"
@@ -608,6 +618,13 @@
       }
     ],
     "menus": {
+      "editor/actions/right": [
+        {
+          "command": "quarto.toggleRenderOnSave",
+          "when": "editorLangId == quarto && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
+          "group": "Quarto"
+        }
+      ],
       "editor/context": [
         {
           "command": "quarto.formatCell",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -436,6 +436,18 @@
         }
       },
       {
+        "command": "quarto.toggleEditMode",
+        "title": "Edit Mode",
+        "category": "Quarto",
+        "enablement": "editorLangId == quarto",
+        "actionBarOptions": {
+          "controlType": "toggle",
+          "leftTitle": "Source",
+          "rightTitle": "Visual",
+          "toggled": "quarto.editMode == 'visual'"
+        }
+      },
+      {
         "command": "quarto.zoteroConfigureLibrary",
         "category": "Quarto",
         "title": "Zotero - Connect Web Library"
@@ -621,6 +633,11 @@
       "editor/actions/right": [
         {
           "command": "quarto.toggleRenderOnSave",
+          "when": "editorLangId == quarto && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
+          "group": "Quarto"
+        },
+        {
+          "command": "quarto.toggleEditMode",
           "when": "editorLangId == quarto && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
           "group": "Quarto"
         }

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -426,16 +426,6 @@
         "enablement": "editorTextFocus && !editorReadonly && editorLangId == quarto"
       },
       {
-        "command": "quarto.toggleRenderOnSave",
-        "title": "Render on Save",
-        "category": "Quarto",
-        "enablement": "editorLangId == quarto",
-        "actionBarOptions": {
-          "controlType": "checkbox",
-          "checked": "(quarto.editor.type == quarto && quarto.editor.renderOnSave) || (quarto.editor.type == 'quarto-shiny' && quarto.editor.renderOnSaveShiny)"
-        }
-      },
-      {
         "command": "quarto.toggleEditMode",
         "title": "Edit Mode",
         "category": "Quarto",
@@ -444,7 +434,17 @@
           "controlType": "toggle",
           "leftTitle": "Source",
           "rightTitle": "Visual",
-          "toggled": "quarto.editMode == 'visual'"
+          "toggled": "activeCustomEditorId == 'quarto.visualEditor'"
+        }
+      },
+      {
+        "command": "quarto.toggleRenderOnSave",
+        "title": "Render on Save",
+        "category": "Quarto",
+        "enablement": "editorLangId == quarto",
+        "actionBarOptions": {
+          "controlType": "checkbox",
+          "checked": "((activeCustomEditorId == 'quarto.visualEditor' || quarto.editor.type == quarto) && quarto.editor.renderOnSave) || ((activeCustomEditorId == 'quarto.visualEditor' || quarto.editor.type == 'quarto-shiny') && quarto.editor.renderOnSaveShiny)"
         }
       },
       {
@@ -633,12 +633,12 @@
       "editor/actions/right": [
         {
           "command": "quarto.toggleRenderOnSave",
-          "when": "editorLangId == quarto && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
+          "when": "(activeCustomEditorId == 'quarto.visualEditor' || editorLangId == quarto) && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
           "group": "Quarto"
         },
         {
           "command": "quarto.toggleEditMode",
-          "when": "editorLangId == quarto && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
+          "when": "(activeCustomEditorId == 'quarto.visualEditor' || editorLangId == quarto) && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
           "group": "Quarto"
         }
       ],

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -103,12 +103,6 @@ export async function activate(context: vscode.ExtensionContext) {
     const assistCommands = activateQuartoAssistPanel(context, engine);
     commands.push(...assistCommands);
   }
-
-  context.subscriptions.push(vscode.commands.registerCommand('quarto.toggleRenderOnSave', () => {
-    toggleRenderOnSaveOverride();
-  }));
-
-
   // walkthough
   commands.push(...walkthroughCommands(host, quartoContext));
 

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -35,7 +35,6 @@ import { extensionHost } from "./host";
 import { initQuartoContext } from "quarto-core";
 import { configuredQuartoPath } from "./core/quarto";
 import { activateDenoConfig } from "./providers/deno-config";
-import { toggleRenderOnSaveOverride } from "./providers/context-keys";
 
 export async function activate(context: vscode.ExtensionContext) {
   // create output channel for extension logs and lsp client logs

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -35,6 +35,7 @@ import { extensionHost } from "./host";
 import { initQuartoContext } from "quarto-core";
 import { configuredQuartoPath } from "./core/quarto";
 import { activateDenoConfig } from "./providers/deno-config";
+import { toggleRenderOnSaveOverride } from "./providers/context-keys";
 
 export async function activate(context: vscode.ExtensionContext) {
   // create output channel for extension logs and lsp client logs
@@ -102,6 +103,11 @@ export async function activate(context: vscode.ExtensionContext) {
     const assistCommands = activateQuartoAssistPanel(context, engine);
     commands.push(...assistCommands);
   }
+
+  context.subscriptions.push(vscode.commands.registerCommand('quarto.toggleRenderOnSave', () => {
+    toggleRenderOnSaveOverride();
+  }));
+
 
   // walkthough
   commands.push(...walkthroughCommands(host, quartoContext));

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -21,11 +21,9 @@ import { MarkdownEngine } from "../markdown/engine";
 import { mainLanguage } from "../vdoc/vdoc";
 import { isQuartoShinyDoc } from "./preview/preview-util";
 import { workspace } from "vscode";
+import { VisualEditorProvider } from "./editor/editor";
 
 const debounceOnDidChangeDocumentMs = 250;
-
-// temporary create an output channel for quarto state changes
-const outputChannel = vscode.window.createOutputChannel("Quarto State", { log: true });
 
 // state for quarto.editor.type context key
 let quartoEditorType: 'quarto' | 'quarto-shiny' | undefined = undefined;
@@ -92,6 +90,16 @@ export function getRenderOnSaveShiny() {
     : renderOnSaveShinyOverride;
 }
 
+// toggles edit mode
+export function toggleEditMode() {
+  const quartoVisualEditor = VisualEditorProvider.activeEditor();
+  if (quartoVisualEditor !== undefined) {
+    vscode.commands.executeCommand('quarto.editInSourceMode');
+  } else {
+    vscode.commands.executeCommand('quarto.editInVisualMode');
+  }
+}
+
 // toggles render on save override
 export function toggleRenderOnSaveOverride() {
   // toggle the render on save override based on the editor type (quarto or quarto-shiny)
@@ -103,7 +111,6 @@ export function toggleRenderOnSaveOverride() {
 
     // toggle the render on save override
     renderOnSaveOverride = !renderOnSaveOverride;
-    outputChannel.info(`Setting quarto.editor.renderOnSave context key to "${renderOnSaveOverride}"`);
     vscode.commands.executeCommand<boolean>('setContext', 'quarto.editor.renderOnSave', renderOnSaveOverride);
   } else if (quartoEditorType === 'quarto-shiny') {
     // if this is the first override, read the quarto.render.renderOnSaveShiny configuration
@@ -113,7 +120,6 @@ export function toggleRenderOnSaveOverride() {
 
     // toggle the render on save override
     renderOnSaveShinyOverride = !renderOnSaveShinyOverride;
-    outputChannel.info(`Setting quarto.editor.renderOnSaveShiny context key to "${renderOnSaveShinyOverride}"`);
     vscode.commands.executeCommand<boolean>('setContext', 'quarto.editor.renderOnSaveShiny', renderOnSaveShinyOverride);
   }
 }
@@ -126,7 +132,6 @@ function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, e
     quartoEditorType = !isQuartoShinyDoc(engine, activeTextEditor?.document)
       ? 'quarto'
       : 'quarto-shiny';
-    outputChannel.info(`Setting quarto.editor.type context key to "${quartoEditorType}"`);
     vscode.commands.executeCommand<string>(
       'setContext',
       'quarto.editor.type',
@@ -137,7 +142,6 @@ function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, e
     const renderOnSave = renderOnSaveOverride === undefined
       ? readRenderOnSaveConfiguration()
       : renderOnSaveOverride;
-    outputChannel.info(`Setting quarto.editor.renderOnSave context key to "${renderOnSave}"`);
     vscode.commands.executeCommand<string>(
       'setContext',
       'quarto.editor.renderOnSave',
@@ -148,7 +152,6 @@ function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, e
     const renderOnSaveShiny = renderOnSaveShinyOverride === undefined ?
       readRenderOnSaveShinyConfiguration() :
       renderOnSaveShinyOverride;
-    outputChannel.info(`Setting quarto.editor.renderOnSaveShiny context key to "${renderOnSaveShiny}"`);
     vscode.commands.executeCommand<string>(
       'setContext',
       'quarto.editor.renderOnSaveShiny',

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -19,51 +19,139 @@ import debounce from "lodash.debounce";
 import { isQuartoDoc } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
 import { mainLanguage } from "../vdoc/vdoc";
+import { isQuartoShinyDoc } from "./preview/preview-util";
+import { workspace } from "vscode";
 
 const debounceOnDidChangeDocumentMs = 250;
+
+// temporary create an output channel for quarto state changes
+const outputChannel = vscode.window.createOutputChannel("Quarto State", { log: true });
+
+// state for quarto.editor.type context key
+let quartoEditorType: 'quarto' | 'quarto-shiny' | undefined = undefined;
+
+// state for quarto.editor.renderOnSave override
+// this is only defined when the user has changed the value at runtime
+let renderOnSaveOverride: boolean | undefined = undefined;
+
+// state for quarto.editor.renderOnSaveShiny override
+// this is only defined when the user has changed the value at runtime
+let renderOnSaveShinyOverride: boolean | undefined = undefined;
 
 export function activateContextKeySetter(
   context: vscode.ExtensionContext,
   engine: MarkdownEngine
 ) {
+  // set the initial context keys
+  setEditorContextKeys(vscode.window.activeTextEditor, engine);
+  setLanguageContextKeys(vscode.window.activeTextEditor, engine);
 
   // set context keys when active text editor changes
-  vscode.window.onDidChangeActiveTextEditor(
-    (editor) => {
-      if (editor) {
-        setContextKeys(editor, engine);
-      }
-    },
+  vscode.window.onDidChangeActiveTextEditor(activeTextEditor => {
+    setEditorContextKeys(activeTextEditor, engine);
+    setLanguageContextKeys(activeTextEditor, engine);
+  },
     null,
     context.subscriptions
   );
 
   // set context keys on changes to the document (if it's active)
-  vscode.workspace.onDidChangeTextDocument(
-    (event) => {
-      const activeEditor = vscode.window.activeTextEditor;
-      if (activeEditor) {
-        debounce(
-          () => setContextKeys(activeEditor, engine),
-          debounceOnDidChangeDocumentMs
-        )();
-      }
-    },
+  vscode.workspace.onDidChangeTextDocument(event => {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor) {
+      debounce(
+        () => setLanguageContextKeys(activeEditor, engine),
+        debounceOnDidChangeDocumentMs
+      )();
+    }
+  },
     null,
     context.subscriptions
   );
 }
 
-function setContextKeys(editor: vscode.TextEditor, engine: MarkdownEngine) {
-  if (!editor || !isQuartoDoc(editor.document)) {
+// toggles render on save override
+export function toggleRenderOnSaveOverride() {
+  if (quartoEditorType === 'quarto') {
+    // if this is the first override, read the quarto.render.renderOnSave configuration
+    if (renderOnSaveOverride === undefined) {
+      renderOnSaveOverride = readRenderOnSaveConfiguration();
+    }
+
+    // toggle the override.
+    renderOnSaveOverride = !renderOnSaveOverride;
+    outputChannel.info(`Setting quarto.editor.renderOnSave context key to "${renderOnSaveOverride}"`);
+    vscode.commands.executeCommand<boolean>('setContext', 'quarto.editor.renderOnSave', renderOnSaveOverride);
+  } else if (quartoEditorType === 'quarto-shiny') {
+    // if this is the first override, read the quarto.render.renderOnSaveShiny configuration
+    if (renderOnSaveShinyOverride === undefined) {
+      renderOnSaveShinyOverride = readRenderOnSaveShinyConfiguration();
+    }
+
+    // toggle the override.
+    renderOnSaveShinyOverride = !renderOnSaveShinyOverride;
+    outputChannel.info(`Setting quarto.editor.renderOnSaveShiny context key to "${renderOnSaveShinyOverride}"`);
+    vscode.commands.executeCommand<boolean>('setContext', 'quarto.editor.renderOnSaveShiny', renderOnSaveShinyOverride);
+  }
+}
+
+function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, engine: MarkdownEngine) {
+  if (isQuartoDoc(activeTextEditor?.document)) {
+    // set the quarto.editor.type context key
+    quartoEditorType = !isQuartoShinyDoc(engine, activeTextEditor?.document) ?
+      'quarto' :
+      'quarto-shiny';
+    outputChannel.info(`Setting quarto.editor.type context key to "${quartoEditorType}"`);
+    vscode.commands.executeCommand<string>(
+      'setContext',
+      'quarto.editor.type',
+      quartoEditorType
+    );
+
+    // set the quarto.editor.renderOnSave context key
+    const renderOnSave = renderOnSaveOverride === undefined ?
+      readRenderOnSaveConfiguration() :
+      renderOnSaveOverride;
+    outputChannel.info(`Setting quarto.editor.renderOnSave context key to "${renderOnSave}"`);
+    vscode.commands.executeCommand<string>(
+      'setContext',
+      'quarto.editor.renderOnSave',
+      renderOnSave
+    );
+
+    // set the quarto.editor.renderOnSaveShiny context key
+    const renderOnSaveShiny = renderOnSaveShinyOverride === undefined ?
+      readRenderOnSaveShinyConfiguration() :
+      renderOnSaveShinyOverride;
+    outputChannel.info(`Setting quarto.editor.renderOnSaveShiny context key to "${renderOnSaveShiny}"`);
+    vscode.commands.executeCommand<string>(
+      'setContext',
+      'quarto.editor.renderOnSaveShiny',
+      renderOnSaveShiny
+    );
+  }
+}
+
+function setLanguageContextKeys(activeTextEditor: vscode.TextEditor | undefined, engine: MarkdownEngine) {
+  if (!activeTextEditor || !isQuartoDoc(activeTextEditor.document)) {
     return;
   }
 
   // expose main language for use in keybindings, etc
-  const tokens = engine.parse(editor.document);
+  const tokens = engine.parse(activeTextEditor.document);
   const language = mainLanguage(tokens);
   vscode.commands.executeCommand(
     'setContext',
     'quarto.document.languageId',
     language?.ids[0]);
+}
+
+// reads the quarto.render.renderOnSave configuration.
+function readRenderOnSaveConfiguration() {
+  return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSave", false);
+}
+
+// reads the quarto.render.renderOnSaveShiny configuration.
+function readRenderOnSaveShinyConfiguration() {
+  return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSaveShiny", true);
 }

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -92,13 +92,14 @@ export function activateContextKeySetter(
 
 // toggles render on save override
 export function toggleRenderOnSaveOverride() {
+  // toggle the render on save override based on the editor type (quarto or quarto-shiny)
   if (quartoEditorType === 'quarto') {
     // if this is the first override, read the quarto.render.renderOnSave configuration
     if (renderOnSaveOverride === undefined) {
       renderOnSaveOverride = readRenderOnSaveConfiguration();
     }
 
-    // toggle the override.
+    // toggle the render on save override
     renderOnSaveOverride = !renderOnSaveOverride;
     outputChannel.info(`Setting quarto.editor.renderOnSave context key to "${renderOnSaveOverride}"`);
     vscode.commands.executeCommand<boolean>('setContext', 'quarto.editor.renderOnSave', renderOnSaveOverride);
@@ -108,7 +109,7 @@ export function toggleRenderOnSaveOverride() {
       renderOnSaveShinyOverride = readRenderOnSaveShinyConfiguration();
     }
 
-    // toggle the override.
+    // toggle the render on save override
     renderOnSaveShinyOverride = !renderOnSaveShinyOverride;
     outputChannel.info(`Setting quarto.editor.renderOnSaveShiny context key to "${renderOnSaveShinyOverride}"`);
     vscode.commands.executeCommand<boolean>('setContext', 'quarto.editor.renderOnSaveShiny', renderOnSaveShinyOverride);
@@ -116,6 +117,7 @@ export function toggleRenderOnSaveOverride() {
 }
 
 function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, engine: MarkdownEngine) {
+  // if a Quarto doc is active, set the editor context keys
   if (isQuartoDoc(activeTextEditor?.document)) {
     // set the quarto.editor.type context key
     quartoEditorType = !isQuartoShinyDoc(engine, activeTextEditor?.document)

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -58,6 +58,14 @@ export function activateContextKeySetter(
   setEditorContextKeys(vscode.window.activeTextEditor, engine);
   setLanguageContextKeys(vscode.window.activeTextEditor, engine);
 
+  // register for render configuration change notification
+  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
+    // if the change affects quarto.render.renderOnSave or quarto.render.renderOnSaveShiny, set the editor context keys.
+    if (event.affectsConfiguration('quarto.render.renderOnSave') || event.affectsConfiguration('quarto.render.renderOnSaveShiny')) {
+      setEditorContextKeys(vscode.window.activeTextEditor, engine);
+    }
+  }));
+
   // set context keys when active text editor changes
   vscode.window.onDidChangeActiveTextEditor(activeTextEditor => {
     setEditorContextKeys(activeTextEditor, engine);

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -38,6 +38,18 @@ let renderOnSaveOverride: boolean | undefined = undefined;
 // this is only defined when the user has changed the value at runtime
 let renderOnSaveShinyOverride: boolean | undefined = undefined;
 
+export function getRenderOnSave() {
+  return renderOnSaveOverride === undefined
+    ? readRenderOnSaveConfiguration()
+    : renderOnSaveOverride;
+}
+
+export function getRenderOnSaveShiny() {
+  return renderOnSaveShinyOverride === undefined
+    ? readRenderOnSaveShinyConfiguration()
+    : renderOnSaveShinyOverride;
+}
+
 export function activateContextKeySetter(
   context: vscode.ExtensionContext,
   engine: MarkdownEngine
@@ -98,9 +110,9 @@ export function toggleRenderOnSaveOverride() {
 function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, engine: MarkdownEngine) {
   if (isQuartoDoc(activeTextEditor?.document)) {
     // set the quarto.editor.type context key
-    quartoEditorType = !isQuartoShinyDoc(engine, activeTextEditor?.document) ?
-      'quarto' :
-      'quarto-shiny';
+    quartoEditorType = !isQuartoShinyDoc(engine, activeTextEditor?.document)
+      ? 'quarto'
+      : 'quarto-shiny';
     outputChannel.info(`Setting quarto.editor.type context key to "${quartoEditorType}"`);
     vscode.commands.executeCommand<string>(
       'setContext',
@@ -109,9 +121,9 @@ function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, e
     );
 
     // set the quarto.editor.renderOnSave context key
-    const renderOnSave = renderOnSaveOverride === undefined ?
-      readRenderOnSaveConfiguration() :
-      renderOnSaveOverride;
+    const renderOnSave = renderOnSaveOverride === undefined
+      ? readRenderOnSaveConfiguration()
+      : renderOnSaveOverride;
     outputChannel.info(`Setting quarto.editor.renderOnSave context key to "${renderOnSave}"`);
     vscode.commands.executeCommand<string>(
       'setContext',

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -38,18 +38,6 @@ let renderOnSaveOverride: boolean | undefined = undefined;
 // this is only defined when the user has changed the value at runtime
 let renderOnSaveShinyOverride: boolean | undefined = undefined;
 
-export function getRenderOnSave() {
-  return renderOnSaveOverride === undefined
-    ? readRenderOnSaveConfiguration()
-    : renderOnSaveOverride;
-}
-
-export function getRenderOnSaveShiny() {
-  return renderOnSaveShinyOverride === undefined
-    ? readRenderOnSaveShinyConfiguration()
-    : renderOnSaveShinyOverride;
-}
-
 export function activateContextKeySetter(
   context: vscode.ExtensionContext,
   engine: MarkdownEngine
@@ -58,7 +46,7 @@ export function activateContextKeySetter(
   setEditorContextKeys(vscode.window.activeTextEditor, engine);
   setLanguageContextKeys(vscode.window.activeTextEditor, engine);
 
-  // register for render configuration change notification
+  // register for quarto.render.renderOnSave or quarto.render.renderOnSaveShiny configuration change notification
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
     // if the change affects quarto.render.renderOnSave or quarto.render.renderOnSaveShiny, set the editor context keys.
     if (event.affectsConfiguration('quarto.render.renderOnSave') || event.affectsConfiguration('quarto.render.renderOnSaveShiny')) {
@@ -90,6 +78,20 @@ export function activateContextKeySetter(
   );
 }
 
+// gets render on save
+export function getRenderOnSave() {
+  return renderOnSaveOverride === undefined
+    ? readRenderOnSaveConfiguration()
+    : renderOnSaveOverride;
+}
+
+// gets render on save shiny
+export function getRenderOnSaveShiny() {
+  return renderOnSaveShinyOverride === undefined
+    ? readRenderOnSaveShinyConfiguration()
+    : renderOnSaveShinyOverride;
+}
+
 // toggles render on save override
 export function toggleRenderOnSaveOverride() {
   // toggle the render on save override based on the editor type (quarto or quarto-shiny)
@@ -116,6 +118,7 @@ export function toggleRenderOnSaveOverride() {
   }
 }
 
+// sets editor context keys
 function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, engine: MarkdownEngine) {
   // if a Quarto doc is active, set the editor context keys
   if (isQuartoDoc(activeTextEditor?.document)) {

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -62,7 +62,8 @@ import { JsonRpcRequestTransport } from "core";
 import {
   editInSourceModeCommand,
   editInVisualModeCommand,
-  renderOnSaveCommand,
+  toggleEditModeCommand,
+  toggleRenderOnSaveCommand,
   reopenEditorInSourceMode
 } from "./toggle";
 import { ExtensionHost } from "../../host";
@@ -88,7 +89,8 @@ export function activateEditor(
   return [
     editInVisualModeCommand(),
     editInSourceModeCommand(),
-    renderOnSaveCommand()
+    toggleEditModeCommand(),
+    toggleRenderOnSaveCommand()
   ];
 }
 

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -14,7 +14,7 @@
  */
 
 import path, { extname, win32 } from "path";
-import { determineMode } from "./toggle"
+import { determineMode } from "./toggle";
 import debounce from "lodash.debounce";
 
 import {
@@ -62,6 +62,7 @@ import { JsonRpcRequestTransport } from "core";
 import {
   editInSourceModeCommand,
   editInVisualModeCommand,
+  renderOnSaveCommand,
   reopenEditorInSourceMode
 } from "./toggle";
 import { ExtensionHost } from "../../host";
@@ -84,7 +85,11 @@ export function activateEditor(
   context.subscriptions.push(VisualEditorProvider.register(context, host, quartoContext, lspClient, engine));
 
   // return commands
-  return [editInVisualModeCommand(), editInSourceModeCommand()];
+  return [
+    editInVisualModeCommand(),
+    editInSourceModeCommand(),
+    renderOnSaveCommand()
+  ];
 }
 
 

--- a/apps/vscode/src/providers/editor/toggle.ts
+++ b/apps/vscode/src/providers/editor/toggle.ts
@@ -20,7 +20,7 @@ import { isQuartoDoc, kQuartoLanguageId } from "../../core/doc";
 import { VisualEditorProvider } from "./editor";
 import { Uri } from "vscode";
 import { hasHooks } from "../../host/hooks";
-import { toggleRenderOnSaveOverride } from "../context-keys";
+import { toggleEditMode, toggleRenderOnSaveOverride } from "../context-keys";
 
 export function determineMode(text: string, uri: Uri): string | undefined {
   let editorOpener = undefined;
@@ -98,7 +98,16 @@ export function editInSourceModeCommand(): Command {
   };
 }
 
-export function renderOnSaveCommand(): Command {
+export function toggleEditModeCommand(): Command {
+  return {
+    id: 'quarto.toggleEditMode',
+    execute() {
+      toggleEditMode();
+    }
+  };
+}
+
+export function toggleRenderOnSaveCommand(): Command {
   return {
     id: 'quarto.toggleRenderOnSave',
     execute() {

--- a/apps/vscode/src/providers/editor/toggle.ts
+++ b/apps/vscode/src/providers/editor/toggle.ts
@@ -20,6 +20,7 @@ import { isQuartoDoc, kQuartoLanguageId } from "../../core/doc";
 import { VisualEditorProvider } from "./editor";
 import { Uri } from "vscode";
 import { hasHooks } from "../../host/hooks";
+import { toggleRenderOnSaveOverride } from "../context-keys";
 
 export function determineMode(text: string, uri: Uri): string | undefined {
   let editorOpener = undefined;
@@ -93,6 +94,15 @@ export function editInSourceModeCommand(): Command {
       if (activeVisual) {
         reopenEditorInSourceMode(activeVisual.document, '', activeVisual.viewColumn);
       }
+    }
+  };
+}
+
+export function renderOnSaveCommand(): Command {
+  return {
+    id: 'quarto.toggleRenderOnSave',
+    execute() {
+      toggleRenderOnSaveOverride();
     }
   };
 }

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -124,7 +124,7 @@ export async function renderOnSave(engine: MarkdownEngine, document: TextDocumen
     }
   }
 
-  // finally, consult configuration.
+  // finally, consult configuration
   return !isQuartoShinyDoc(engine, document)
     ? getRenderOnSave()
     : getRenderOnSaveShiny();
@@ -137,18 +137,10 @@ export function haveNotebookSaveEvents() {
   );
 }
 
-/**
- * Reads the quarto.render.renderOnSave configuration.
- * @returns A boolean which indicates whether quarto.render.renderOnSave is enabled.
- */
 function readRenderOnSaveConfiguration() {
   return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSave", false);
 }
 
-/**
- * Reads the quarto.render.renderOnSaveShiny configuration.
- * @returns A boolean which indicates whether quarto.render.renderOnSaveShiny is enabled.
- */
 function readRenderOnSaveShinyConfiguration() {
   return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSaveShiny", true);
 }

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -28,6 +28,7 @@ import { isNotebook } from "../../core/doc";
 import { MarkdownEngine } from "../../markdown/engine";
 import { documentFrontMatter } from "../../markdown/document";
 import { isKnitrDocument } from "../../host/executors";
+import { getRenderOnSave, getRenderOnSaveShiny } from "../context-keys";
 
 
 export function isQuartoShinyDoc(
@@ -125,8 +126,8 @@ export async function renderOnSave(engine: MarkdownEngine, document: TextDocumen
 
   // finally, consult configuration.
   return !isQuartoShinyDoc(engine, document)
-    ? readRenderOnSaveConfiguration()
-    : readRenderOnSaveShinyConfiguration();
+    ? getRenderOnSave()
+    : getRenderOnSaveShiny();
 }
 
 export function haveNotebookSaveEvents() {

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -137,14 +137,6 @@ export function haveNotebookSaveEvents() {
   );
 }
 
-function readRenderOnSaveConfiguration() {
-  return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSave", false);
-}
-
-function readRenderOnSaveShinyConfiguration() {
-  return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSaveShiny", true);
-}
-
 function readRenderOnSave(yaml: Record<string, unknown>) {
   if (typeof yaml["editor"] === "object") {
     const yamlObj = yaml["editor"] as Record<string, unknown>;

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -123,13 +123,10 @@ export async function renderOnSave(engine: MarkdownEngine, document: TextDocumen
     }
   }
 
-  // finally, consult vs code settings
-  const config = workspace.getConfiguration("quarto");
-  const render = isQuartoShinyDoc(engine, document)
-    ? config.get<boolean>("render.renderOnSaveShiny", true)
-    : config.get<boolean>("render.renderOnSave", false);
-
-  return render;
+  // finally, consult configuration.
+  return !isQuartoShinyDoc(engine, document)
+    ? readRenderOnSaveConfiguration()
+    : readRenderOnSaveShinyConfiguration();
 }
 
 export function haveNotebookSaveEvents() {
@@ -137,6 +134,22 @@ export function haveNotebookSaveEvents() {
     semver.gte(vscode.version, "1.67.0") &&
     !!(workspace as any).onDidSaveNotebookDocument
   );
+}
+
+/**
+ * Reads the quarto.render.renderOnSave configuration.
+ * @returns A boolean which indicates whether quarto.render.renderOnSave is enabled.
+ */
+function readRenderOnSaveConfiguration() {
+  return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSave", false);
+}
+
+/**
+ * Reads the quarto.render.renderOnSaveShiny configuration.
+ * @returns A boolean which indicates whether quarto.render.renderOnSaveShiny is enabled.
+ */
+function readRenderOnSaveShinyConfiguration() {
+  return workspace.getConfiguration("quarto").get<boolean>("render.renderOnSaveShiny", true);
 }
 
 function readRenderOnSave(yaml: Record<string, unknown>) {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
     "eslint-config-custom": "*",
     "prettier": "^2.5.1",
     "turbo": "^1.8.5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,5 @@
     "eslint-config-custom": "*",
     "prettier": "^2.5.1",
     "turbo": "^1.8.5"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
This PR updates the Quarto extension so that it places two new controls on the Positron Editor Action Bar. Those controls are:

- A toggle switch for changing between Source and Visual editing mode.
- A checkbox to enable or disable Render on Save for the current editing session.

Here's a video that shows these controls in action:

https://github.com/user-attachments/assets/af338522-c05e-491a-8591-17f89fbca2a4

The Source / Visual toggle control is quite straightforward.

The Render on Save checkbox control appears when a **Quarto** or **Quarto Shiny** document is open and it allows the user to independently override the configuration settings for **Quarto > Render: Render on Save** and **Quarto > Render: Render on Save Shiny**, depending on the document type, in the current editing session.