### PR TITLE
Improved (less aggressive) editor focus preservation behavior

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.121.0 (unreleased)
 
 - Add new controls for Positron editor action bar (<https://github.com/quarto-dev/quarto/pull/698>).
+- Improved editor focus preservation behavior.
 
 ## 1.120.0 (Release on 2025-04-07)
 

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.121.0 (unreleased)
 
 - Add new controls for Positron editor action bar (<https://github.com/quarto-dev/quarto/pull/698>).
-- Improved editor focus preservation behavior.
+- Improve editor focus preservation behavior (<https://github.com/quarto-dev/quarto/pull/699>).
 
 ## 1.120.0 (Release on 2025-04-07)
 

--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -204,13 +204,13 @@ export async function previewDoc(
     previewManager.setOnShow(onShow);
   }
 
-  // activate the editor
-  if (!isNotebook(editor.document)) {
-    await editor.activate();
-  }
-
-  // if this wasn't a renderOnSave then save
+  // if this wasn't a renderOnSave then activate the editor and save
   if (!renderOnSave) {
+    // activate the editor
+    if (!isNotebook(editor.document)) {
+      await editor.activate();
+    }
+
     await commands.executeCommand("workbench.action.files.save");
     if (editor.document.isDirty) {
       return;
@@ -247,8 +247,10 @@ export async function previewDoc(
     );
 
     // focus the editor (sometimes the terminal steals focus)
-    if (!isNotebook(previewEditor.document)) {
-      await previewEditor.activate();
+    if (!renderOnSave) {
+      if (!isNotebook(previewEditor.document)) {
+        await previewEditor.activate();
+      }
     }
   }
 }

--- a/apps/vscode/src/providers/webview.ts
+++ b/apps/vscode/src/providers/webview.ts
@@ -81,7 +81,6 @@ export class QuartoWebviewManager<T extends QuartoWebview<S>, S> {
     if (this.activeView_) {
       this.activeView_.reveal();
       this.resolveOnShow();
-      preserveEditorFocus();
     }
   }
 


### PR DESCRIPTION
- Don't preserve focus during render on save as this often ends up stealing focus from the terminal (which can lead to stray characters in documents).
- Don't preserve focus after revealing preview window (we already tell vscode to preserveFocus -- this used to be inconsistently respected but now seems to work properly).