### PR TITLE
Update Positron editor actions

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.122.0 (unreleased)
 
+- Change controls on Positron editor action bar and fix "Render on Save" behavior (<https://github.com/quarto-dev/quarto/pull/706>).
+
 ## 1.121.0 (Release on 2025-05-02)
 
 - Add new controls for Positron editor action bar (<https://github.com/quarto-dev/quarto/pull/698>).

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -448,7 +448,7 @@
         "enablement": "editorLangId == quarto",
         "actionBarOptions": {
           "controlType": "checkbox",
-          "checked": "((activeCustomEditorId == 'quarto.visualEditor' || quarto.editor.type == quarto) && quarto.editor.renderOnSave) || ((activeCustomEditorId == 'quarto.visualEditor' || quarto.editor.type == 'quarto-shiny') && quarto.editor.renderOnSaveShiny)"
+          "checked": "(quarto.editor.type == quarto && quarto.editor.renderOnSave) || (quarto.editor.type == 'quarto-shiny' && quarto.editor.renderOnSaveShiny)"
         }
       },
       {
@@ -634,16 +634,21 @@
       }
     ],
     "menus": {
-      "editor/actions/right": [
+      "editor/actions/left": [
+        {
+          "command": "quarto.preview",
+          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'",
+          "group": "0_preview"
+        },
         {
           "command": "quarto.toggleRenderOnSave",
-          "when": "(activeCustomEditorId == 'quarto.visualEditor' || editorLangId == quarto) && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
-          "group": "Quarto"
+          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'",
+          "group": "0_preview"
         },
         {
           "command": "quarto.toggleEditMode",
-          "when": "(activeCustomEditorId == 'quarto.visualEditor' || editorLangId == quarto) && (quarto.editor.type == quarto || quarto.editor.type == 'quarto-shiny')",
-          "group": "Quarto"
+          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'",
+          "group": "1_editor_mode"
         }
       ],
       "editor/context": [

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -66,7 +66,10 @@ export function activateContextKeySetter(
     const activeEditor = vscode.window.activeTextEditor;
     if (activeEditor) {
       debounce(
-        () => setLanguageContextKeys(activeEditor, engine),
+        () => {
+          setEditorContextKeys(activeEditor, engine)
+          setLanguageContextKeys(activeEditor, engine)
+        },
         debounceOnDidChangeDocumentMs
       )();
     }


### PR DESCRIPTION
This PR makes a few adjustments to how the "Preview", "Render on Save" and "Source | Visual" UI controls appear on the Positron Editor Action Bar. These controls are now positioned on the left side of the Positron Editor Action Bar.

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/0e3b8b1a-faea-469a-86a4-cc430639dc55" />

Additionally, this PR fixes a few bugs that were causing the "Render on Save" checkbox to be out of sync in certain scenarios.