### PR TITLE
Support inlay hints in code chunks

### DIFF
--- a/apps/lsp/src/middleware.ts
+++ b/apps/lsp/src/middleware.ts
@@ -28,7 +28,8 @@ export function middlewareCapabilities() : ServerCapabilities {
     },
     documentFormattingProvider: true,
     documentRangeFormattingProvider: true,
-    definitionProvider: true
+    definitionProvider: true,
+    inlayHintProvider: true
   }
 };
 

--- a/apps/vscode/src/providers/inlay-hints.ts
+++ b/apps/vscode/src/providers/inlay-hints.ts
@@ -18,9 +18,9 @@ export function embeddedInlayHintsProvider(engine: MarkdownEngine) {
     range: Range,
     token: CancellationToken,
     next: ProvideInlayHintsSignature
-  ): Promise<InlayHint[] | undefined> => {
+  ): Promise<InlayHint[] | null | undefined> => {
     if (!isQuartoDoc(document, true)) {
-      return await next(document, range, token) ?? undefined;
+      return await next(document, range, token);
     }
 
     const tokens = engine.parse(document);

--- a/apps/vscode/src/providers/inlay-hints.ts
+++ b/apps/vscode/src/providers/inlay-hints.ts
@@ -9,7 +9,7 @@ import {
 import { ProvideInlayHintsSignature } from "vscode-languageclient";
 import { unadjustedPosition, adjustedRange, languages, virtualDocForLanguage, withVirtualDocUri, unadjustedRange } from "../vdoc/vdoc";
 import { MarkdownEngine } from "../markdown/engine";
-import { isQuartoDoc } from "../core/doc";
+import { isQuartoDoc, isQuartoYaml } from "../core/doc";
 
 /**
  * Provides inlay hints for all embedded languages within a single document
@@ -27,6 +27,13 @@ export function embeddedInlayHintsProvider(engine: MarkdownEngine) {
     token: CancellationToken,
     next: ProvideInlayHintsSignature
   ): Promise<InlayHint[] | null | undefined> => {
+    if (isQuartoYaml(document)) {
+      // The LSP client tracks quarto related yaml files like `_quarto.yaml`,
+      // but we don't provide inlay hints for these. Calling `next()` results
+      // in an "unhandled method" toast notification, so we return `undefined`
+      // directly instead. Is there a better solution?
+      return undefined;
+    }
     if (!isQuartoDoc(document, true)) {
       return await next(document, range, token);
     }

--- a/apps/vscode/src/providers/inlay-hints.ts
+++ b/apps/vscode/src/providers/inlay-hints.ts
@@ -1,0 +1,76 @@
+import { InlayHint, Range } from "vscode";
+import {
+  CancellationToken,
+  commands,
+  Position,
+  TextDocument,
+} from "vscode";
+
+import { ProvideInlayHintsSignature } from "vscode-languageclient";
+import { unadjustedPosition, adjustedRange, languageAtPosition, virtualDoc, virtualDocUri } from "../vdoc/vdoc";
+import { MarkdownEngine } from "../markdown/engine";
+
+import { isQuartoDoc } from "../core/doc";
+
+export function embeddedInlayHintsProvider(engine: MarkdownEngine) {
+  return async (
+    document: TextDocument,
+    range: Range,
+    token: CancellationToken,
+    next: ProvideInlayHintsSignature
+  ): Promise<InlayHint[] | undefined> => {
+    if (!isQuartoDoc(document, true)) {
+      return await next(document, range, token) ?? undefined;
+    }
+
+    const tokens = engine.parse(document);
+
+    // Find the start position of each embedded language
+    const languagePositions: Map<String, Position> = new Map();
+    for (let line = range.start.line; line < range.end.line; line++) {
+      const pos = new Position(line, 0);
+      const lang = languageAtPosition(tokens, pos)?.extension;
+      if (lang && !languagePositions.has(lang)) {
+        languagePositions.set(lang, pos);
+      }
+    }
+
+    // Fetch inlay hints for each embedded language
+    const allHints: InlayHint[] = [];
+    for (const [lang, pos] of languagePositions.entries()) {
+      const vdoc = await virtualDoc(document, pos, engine);
+      if (!vdoc) {
+        console.error(`[InlayHints] No virtual document produced for ${lang} at ${pos.line}`);
+        continue;
+      };
+
+      const vdocUri = await virtualDocUri(vdoc, document.uri, "inlayHints");
+      const vRange = adjustedRange(vdoc.language, range);
+
+      console.log(`[Inlayhints} Language vdoc handled: ${lang} of ${vdocUri.uri.toString()} at ${pos.line}`);
+
+      try {
+        const hints = await commands.executeCommand<InlayHint[]>(
+          "vscode.executeInlayHintProvider",
+          vdocUri.uri,
+          vRange
+        );
+        // Map results back to original doc range if needed (optional for inlay hints)
+        if (hints && hints.length > 0) {
+          hints.forEach((hint) => {
+            hint.position = unadjustedPosition(vdoc.language, hint.position);
+          });
+          allHints.push(...hints);
+        }
+      } catch (e) {
+        console.warn(`[InlayHints] Error getting hints for ${lang}:`, e);
+      } finally {
+        if (vdocUri.cleanup) {
+          await vdocUri.cleanup();
+        }
+      }
+    }
+
+    return allHints;
+  };
+}

--- a/apps/vscode/src/providers/inlay-hints.ts
+++ b/apps/vscode/src/providers/inlay-hints.ts
@@ -47,8 +47,6 @@ export function embeddedInlayHintsProvider(engine: MarkdownEngine) {
       const vdocUri = await virtualDocUri(vdoc, document.uri, "inlayHints");
       const vRange = adjustedRange(vdoc.language, range);
 
-      console.log(`[Inlayhints} Language vdoc handled: ${lang} of ${vdocUri.uri.toString()} at ${pos.line}`);
-
       try {
         const hints = await commands.executeCommand<InlayHint[]>(
           "vscode.executeInlayHintProvider",

--- a/apps/vscode/src/providers/inlay-hints.ts
+++ b/apps/vscode/src/providers/inlay-hints.ts
@@ -57,6 +57,13 @@ export function embeddedInlayHintsProvider(engine: MarkdownEngine) {
         if (hints && hints.length > 0) {
           hints.forEach((hint) => {
             hint.position = unadjustedPosition(vdoc.language, hint.position);
+            if (Array.isArray(hint.textEdits) && hint.textEdits.length > 0) {
+              hint.textEdits.forEach((edit) => {
+                const start = unadjustedPosition(vdoc.language, edit.range.start);
+                const end = unadjustedPosition(vdoc.language, edit.range.end);
+                edit.range = new Range(start, end);
+              });
+            }
           });
           allHints.push(...hints);
         }

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -114,6 +114,7 @@ export function virtualDocForCode(code: string[], language: EmbeddedLanguage) {
 export type VirtualDocAction =
   "completion" |
   "hover" |
+  "inlayHints" |
   "signature" |
   "definition" |
   "format" |
@@ -209,6 +210,13 @@ export function adjustedPosition(language: EmbeddedLanguage, pos: Position) {
 
 export function unadjustedPosition(language: EmbeddedLanguage, pos: Position) {
   return new Position(pos.line - (language.inject?.length || 0), pos.character);
+}
+
+export function adjustedRange(language: EmbeddedLanguage, range: Range) {
+  return new Range(
+    adjustedPosition(language, range.start),
+    adjustedPosition(language, range.end)
+  );
 }
 
 export function unadjustedRange(language: EmbeddedLanguage, range: Range) {

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -189,6 +189,39 @@ export function mainLanguage(
   }
 }
 
+/**
+ * Compute the unique set of `EmbeddedLanguages` found within this array of `Token[]`
+ */
+export function languages(
+  tokens: Token[]
+): EmbeddedLanguage[] {
+  const ids = new Set<string>();
+  const languages: EmbeddedLanguage[] = [];
+
+  tokens.filter(isExecutableLanguageBlock).forEach(token => {
+    const language = languageFromBlock(token);
+
+    if (!language) {
+      // This would be unexpected since we filtered to executable language blocks
+      return;
+    }
+
+    // `EmbeddedLanguage` doesn't have a unique identifier, it probably should.
+    // For now we join all `ids` and call that the identifier.
+    const id = language.ids.join("-");
+
+    if (ids.has(id)) {
+      // We've seen this `EmbeddedLanguage` already
+      return;
+    }
+
+    ids.add(id);
+    languages.push(language);
+  });
+
+  return languages;
+}
+
 export function languageFromBlock(token: Token) {
   const name = languageNameFromBlock(token);
   return embeddedLanguage(name);


### PR DESCRIPTION
Use `vscode.executeInlayHintProvider` to retrieve hints for virtual docs and convert the ranges.

Here's a demo (with basedpyright+Positron)

https://github.com/user-attachments/assets/b501c2d0-24b7-4639-afd3-1e7a50d204a9

