### PR TITLE
Add "insert code cell" to editor action bar

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.122.0 (unreleased)
 
 - Change controls on Positron editor action bar and fix "Render on Save" behavior (<https://github.com/quarto-dev/quarto/pull/706>).
+- Add additional new control ("Insert Code Cell") to Positron editor action bar (<https://github.com/quarto-dev/quarto/pull/709>).
 
 ## 1.121.0 (Release on 2025-05-02)
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -296,8 +296,13 @@
       },
       {
         "command": "quarto.insertCodeCell",
+        "icon": "$(insert)",
         "title": "Insert Code Cell",
-        "category": "Quarto"
+        "category": "Quarto",
+        "actionBarOptions": {
+          "controlType": "button",
+          "displayTitle": true
+        }
       },
       {
         "command": "quarto.runSelection",
@@ -649,6 +654,13 @@
           "command": "quarto.toggleEditMode",
           "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'",
           "group": "1_editor_mode"
+        }
+      ],
+      "editor/actions/right": [
+        {
+          "command": "quarto.insertCodeCell",
+          "when": "editorLangId == quarto",
+          "group": "2_execute"
         }
       ],
       "editor/context": [


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3923

This first go at this puts the new button on the right, includes the label, and uses the "insert" icon:

<img width="1299" alt="Screenshot 2025-05-17 at 5 19 56 PM" src="https://github.com/user-attachments/assets/f0b36bdc-5d05-47cf-a3c8-54a41dea62a8" />

We can't fit it on the left, since adding it there pushes `"editor/actions/left"` to past the center mark, and the labels don't all fit and get borked. We may want to change how the labels on the editor action bar behave when they run out of space.

- Do we want to include the label? RStudio does not and seems like folks know how to use it.
- Do we want to use this "insert" icon? Another option would be the "plus" icon, or making a new one.

