### PR TITLE
Turn off visual mode completions in Positron

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.122.0 (unreleased)
 
 - Change controls on Positron editor action bar and fix "Render on Save" behavior (<https://github.com/quarto-dev/quarto/pull/706>).
+- Turn off completions in visual mode in Positron, as a temporary stopgap until we can invest more in LSP features in the visual editor (<https://github.com/quarto-dev/quarto/pull/710>).
 
 ## 1.121.0 (Release on 2025-05-02)
 

--- a/apps/vscode/src/providers/editor/codeview.ts
+++ b/apps/vscode/src/providers/editor/codeview.ts
@@ -85,10 +85,7 @@ export function vscodeCodeViewServer(_engine: MarkdownEngine, document: TextDocu
         // see if we have an embedded langaage
         const language = embeddedLanguage(context.language);
 
-        // is this in Positron? If so, no completions
-        // TODO: fix LSP issues for visual editor in Positron:
-        // https://github.com/posit-dev/positron/issues/1805
-        if (language && !hasHooks()) {
+        if (language) {
 
           // if this is a yaml comment line then call the lsp
           const line = context.code[context.selection.start.line];
@@ -96,7 +93,11 @@ export function vscodeCodeViewServer(_engine: MarkdownEngine, document: TextDocu
             return lspCellYamlOptionsCompletions(context, lspRequest);
 
             // otherwise delegate to vscode completion system
-          } else {
+            // is this in Positron? If so, no completions
+            // TODO: fix LSP issues for visual editor in Positron:
+            // https://github.com/posit-dev/positron/issues/1805
+          }
+          if (!hasHooks()) {
             const vdoc = virtualDocForCode(context.code, language);
             const completions = await vdocCompletions(
               vdoc,
@@ -113,12 +114,11 @@ export function vscodeCodeViewServer(_engine: MarkdownEngine, document: TextDocu
               isIncomplete: false
             };
           }
-        } else {
-          return {
-            items: [],
-            isIncomplete: false
-          };
         }
+        return {
+          items: [],
+          isIncomplete: false
+        };
       }
     },
     async codeViewPreviewDiagram(state: DiagramState, activate: boolean) {

--- a/apps/vscode/src/providers/editor/codeview.ts
+++ b/apps/vscode/src/providers/editor/codeview.ts
@@ -45,6 +45,7 @@ import {
   kCodeViewGetCompletions,
 } from "editor-types";
 
+import { hasHooks } from "../../host/hooks";
 import { embeddedLanguage } from "../../vdoc/languages";
 import { virtualDocForCode } from "../../vdoc/vdoc";
 import { vdocCompletions } from "../../vdoc/vdoc-completion";
@@ -83,7 +84,11 @@ export function vscodeCodeViewServer(_engine: MarkdownEngine, document: TextDocu
 
         // see if we have an embedded langaage
         const language = embeddedLanguage(context.language);
-        if (language) {
+
+        // is this in Positron? If so, no completions
+        // TODO: fix LSP issues for visual editor in Positron:
+        // https://github.com/posit-dev/positron/issues/1805
+        if (language && !hasHooks()) {
 
           // if this is a yaml comment line then call the lsp
           const line = context.code[context.selection.start.line];


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/7201

This PR turns off the completions in the custom visual editor in Positron. I think the completions are similarly pretty bad in the visual editor in VS Code, but to be conservative, this PR only turns them off in Positron. If you look in that `codeview.ts` file, I think the completions are the only thing we really want to turn off for now, to avoid the truly heinous experience people are getting currently.

This does _not_ address https://github.com/posit-dev/positron/issues/7709 because the problem there is that the statement range provider isn't getting piped through to the visual editor at all; there is nothing to turn off there. The other not-so-great experiences we outline in https://github.com/posit-dev/positron/issues/1805 are because we are similarly _not_ providing something (for example, hover help), not because we are providing something badly that we can temporarily turn off.

## QA Notes

- You should get completions in the YAML headers of `.qmd`, in both visual and source
- You should still get completions in source editing, the same that you would get in a regular `.py` or `.R` file
- You should now _not_ get completions in a visual editor