### PR TITLE
Remove `virtualDocUri()` as a footgun

### DIFF
--- a/apps/vscode/src/host/hooks.ts
+++ b/apps/vscode/src/host/hooks.ts
@@ -20,7 +20,7 @@ import { ExtensionHost, HostWebviewPanel, HostStatementRangeProvider, HostHelpTo
 import { CellExecutor, cellExecutorForLanguage, executableLanguages, isKnitrDocument, pythonWithReticulate } from './executors';
 import { ExecuteQueue } from './execute-queue';
 import { MarkdownEngine } from '../markdown/engine';
-import { virtualDoc, virtualDocUri, adjustedPosition, unadjustedRange, withVirtualDocUri } from "../vdoc/vdoc";
+import { virtualDoc, adjustedPosition, unadjustedRange, withVirtualDocUri } from "../vdoc/vdoc";
 import { EmbeddedLanguage } from '../vdoc/languages';
 
 declare global {

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -251,16 +251,13 @@ function embeddedSignatureHelpProvider(engine: MarkdownEngine) {
   ) => {
     const vdoc = await virtualDoc(document, position, engine);
     if (vdoc) {
-      const vdocUri = await virtualDocUri(vdoc, document.uri, "signature");
-      try {
-        return getSignatureHelpHover(vdocUri.uri, vdoc.language, position, context.triggerCharacter);
-      } catch (error) {
-        return undefined;
-      } finally {
-        if (vdocUri.cleanup) {
-          await vdocUri.cleanup();
+      return await withVirtualDocUri(vdoc, document.uri, "signature", async (uri: Uri) => {
+        try {
+          return await getSignatureHelpHover(uri, vdoc.language, position, context.triggerCharacter);
+        } catch (error) {
+          return undefined;
         }
-      }
+      });
     } else {
       return await next(document, position, context, token);
     }

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -52,7 +52,6 @@ import {
   adjustedPosition,
   unadjustedRange,
   virtualDoc,
-  virtualDocUri,
   withVirtualDocUri,
 } from "../vdoc/vdoc";
 import { activateVirtualDocEmbeddedContent } from "../vdoc/vdoc-content";

--- a/apps/vscode/src/providers/assist/render-assist.ts
+++ b/apps/vscode/src/providers/assist/render-assist.ts
@@ -35,7 +35,7 @@ import {
 import { JsonRpcRequestTransport, escapeRegExpCharacters } from "core";
 import { CodeViewCellContext, kCodeViewAssist } from "editor-types";
 import { embeddedLanguage } from "../../vdoc/languages";
-import { virtualDocForCode, virtualDocUri, withVirtualDocUri } from "../../vdoc/vdoc";
+import { virtualDocForCode, withVirtualDocUri } from "../../vdoc/vdoc";
 import { getHover, getSignatureHelpHover } from "../../core/hover";
 import { Hover as LspHover, MarkupKind } from "vscode-languageserver-types";
 import { MarkupContent } from "vscode-languageclient";

--- a/apps/vscode/src/providers/format.ts
+++ b/apps/vscode/src/providers/format.ts
@@ -44,7 +44,6 @@ import {
   VirtualDoc,
   virtualDocForCode,
   virtualDocForLanguage,
-  virtualDocUri,
   withVirtualDocUri,
 } from "../vdoc/vdoc";
 

--- a/apps/vscode/src/vdoc/vdoc-completion.ts
+++ b/apps/vscode/src/vdoc/vdoc-completion.ts
@@ -15,7 +15,7 @@
 
 import { commands, Position, Uri, CompletionList, CompletionItem, Range } from "vscode";
 import { EmbeddedLanguage } from "./languages";
-import { adjustedPosition, unadjustedRange, VirtualDoc, virtualDocUri, withVirtualDocUri } from "./vdoc";
+import { adjustedPosition, unadjustedRange, VirtualDoc, withVirtualDocUri } from "./vdoc";
 
 export async function vdocCompletions(
   vdoc: VirtualDoc,

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -141,7 +141,7 @@ export async function withVirtualDocUri<T>(
   }
 }
 
-export async function virtualDocUri(
+async function virtualDocUri(
   virtualDoc: VirtualDoc,
   parentUri: Uri,
   action: VirtualDocAction

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -127,7 +127,7 @@ export async function withVirtualDocUri<T>(
   parentUri: Uri,
   action: VirtualDocAction,
   f: (uri: Uri) => Promise<T>
-) {
+): Promise<T> {
   const vdocUri = await virtualDocUri(vdoc, parentUri, action);
 
   try {

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -122,6 +122,16 @@ export type VirtualDocAction =
 
 export type VirtualDocUri = { uri: Uri, cleanup?: () => Promise<void> };
 
+/**
+ * Execute a callback on a virtual document's temporary URI
+ *
+ * This method automatically cleans up the temporary URI after executing `f`.
+ *
+ * @param vdoc The virtual document to create a temporary URI for
+ * @param parentUri The virtual document's original URI it was virtualized from
+ * @param f The callback to execute
+ * @returns A Promise evaluating to an object of type `T` returned by `f`
+ */
 export async function withVirtualDocUri<T>(
   vdoc: VirtualDoc,
   parentUri: Uri,
@@ -141,6 +151,9 @@ export async function withVirtualDocUri<T>(
   }
 }
 
+// To be used through `withVirtualDocUri()`. Not safe to export on its own! The
+// cleanup hook must be called, and relying on the caller to do this is a huge
+// footgun.
 async function virtualDocUri(
   virtualDoc: VirtualDoc,
   parentUri: Uri,

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -130,6 +130,8 @@ export async function withVirtualDocUri<T>(
 ): Promise<T> {
   const vdocUri = await virtualDocUri(vdoc, parentUri, action);
 
+  // try-finally without a catch allows `f()` to propagate an exception up to the caller
+  // while still allowing us to clean up the vdoc tempfile.
   try {
     return await f(vdocUri.uri);
   } finally {


### PR DESCRIPTION
There were 3 remaining places where we used `virtualDocUri()` instead of `withVirtualDocUri()`. The ad hoc usage of this is scary because it requires us to carefully analyze the call to ensure we call the `cleanup()` hook (https://github.com/quarto-dev/quarto/issues/708). `withVirtualDocUri()` always handles this, so this PR removes `virtualDocUri()` as a footgun altogether by routing everything through `withVirtualDocUri()` and then unexporting `virtualDocUri()`.