### PR TITLE
Permadelete `.vdoc` temp files, bypassing the trash

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.122.0 (unreleased)
 
+- Language server temporary files are now permanently deleted, bypassing the trash can (<https://github.com/quarto-dev/quarto/pull/714>).
 - Change controls on Positron editor action bar and fix "Render on Save" behavior (<https://github.com/quarto-dev/quarto/pull/706>).
 
 ## 1.121.0 (Release on 2025-05-02)

--- a/apps/vscode/src/vdoc/vdoc-tempfile.ts
+++ b/apps/vscode/src/vdoc/vdoc-tempfile.ts
@@ -75,12 +75,21 @@ export async function virtualDocUriFromTempFile(
   };
 }
 
-// delete a document
+/**
+ * Delete a virtual document's on disk temporary file
+ *
+ * Since this is an ephemeral file, we bypass the trash (Trash on Mac, Recycle
+ * Bin on Windows) and permadelete it instead so our trash isn't cluttered with
+ * thousands of these files. This should also avoid issues with users on network
+ * drives, which don't necessarily have access to their Recycle Bin (#708).
+ *
+ * @param doc The `TextDocument` to delete
+ */
 async function deleteDocument(doc: TextDocument) {
   try {
-    const edit = new WorkspaceEdit();
-    edit.deleteFile(doc.uri);
-    await workspace.applyEdit(edit);
+    await workspace.fs.delete(doc.uri, {
+      useTrash: false
+    });
   } catch (error) {
     const msg = error instanceof Error ? error.message : JSON.stringify(error);
     console.log(`Error removing vdoc at ${doc.fileName}: ${msg}`);


### PR DESCRIPTION
Closes https://github.com/quarto-dev/quarto/issues/708

I'm optimistic that this will help with #708. Even if it doesn't, we should still do this because right now these ephemeral files are piling up in the user's trash can, and they should really be permadeleted.

Before (I triggered completions and help):

<img width="841" alt="Screenshot 2025-05-19 at 1 47 31 PM" src="https://github.com/user-attachments/assets/5e06933e-63b1-489a-91cc-ea595f3ecb97" />


After (same as above, note how no `.vdoc` files appear in my trash now):

<img width="1104" alt="Screenshot 2025-05-19 at 1 48 50 PM" src="https://github.com/user-attachments/assets/4e73b8f3-49de-41a2-9dd4-7b5faa71034c" />

