### PR TITLE
Record pending switches to source/visual in Positron 

### DIFF
--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -175,7 +175,7 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
             // as the tab in `window.tabGroups`, so if we try and close `tab` we
             // get a "tab not found" error. The one we care about does exist, but we have
             // manually find it via URI, which is a stable field to match on.
-            if (editorMode && editorMode != viewType && !isSwitch) {
+            if (editorMode && editorMode !== viewType && !isSwitch) {
               const allTabs = window.tabGroups.all.flatMap(group => group.tabs);
 
               // find tab to close if swapping editor type

--- a/apps/vscode/src/providers/editor/toggle.ts
+++ b/apps/vscode/src/providers/editor/toggle.ts
@@ -121,6 +121,8 @@ export async function reopenEditorInVisualMode(
   viewColumn?: ViewColumn
 ) {
   if (hasHooks()) {
+    // note pending switch to visual
+    VisualEditorProvider.recordPendingSwitchToVisual(document);
     commands.executeCommand('positron.reopenWith', document.uri, 'quarto.visualEditor');
   } else {
     // save then close
@@ -144,6 +146,9 @@ export async function reopenEditorInSourceMode(
   viewColumn?: ViewColumn
 ) {
   if (hasHooks()) {
+    // note pending switch to source
+    VisualEditorProvider.recordPendingSwitchToSource(document);
+
     commands.executeCommand('positron.reopenWith', document.uri, 'default');
   } else {
     if (!document.isUntitled) {


### PR DESCRIPTION
Related to my work in https://github.com/quarto-dev/quarto/pull/684, which did _not_ include these needed pending switches

Addresses [#7305](https://github.com/posit-dev/positron/issues/7305)