### PR TITLE
Specify a required version of Positron

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -28,7 +28,8 @@
   ],
   "private": true,
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.75.0",
+    "positron": "^2025.6.0"
   },
   "main": "./out/main.js",
   "browser": "./browser.js",


### PR DESCRIPTION
Related to https://github.com/posit-dev/positron/pull/8058

I was a bit on the fence about what to require here and am very open to feedback. 

- The absolute minimum would be 2025.04.0, to protect against the failure seen in https://github.com/quarto-dev/quarto/issues/689. 
- I would love to get a version that includes https://github.com/posit-dev/positron/pull/7860, but that first showed up in build 2025.06.0-167 so I think we'd have to do 2025.07.0 (right?) and that is too aggressive as of today.

Thoughts?