### PR TITLE
Build LSP directly in destination so source maps are correct

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,11 +6,13 @@ on:
     branches:
       - main
     paths:
+      - 'apps/lsp/**'
       - 'apps/vscode/**'
   pull_request:
     branches:
       - main
     paths:
+      - 'apps/lsp/**'
       - 'apps/vscode/**'
   workflow_dispatch:
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,9 @@
       "name": "Attach to VS Code LSP Server",
       "port": 6009,
       "restart": true,
-      "outFiles": ["${workspaceRoot}/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/apps/vscode/out/lsp/**/*.js"
+      ]
     }
-	]
+  ]
 }

--- a/apps/lsp/build.ts
+++ b/apps/lsp/build.ts
@@ -23,13 +23,13 @@ const nodeSqlLiteWasm = '../../node_modules/node-sqlite3-wasm/dist/*.wasm';
 
 runBuild({
   entryPoints: ['./src/index.ts'],
-  outfile: './dist/lsp.js',
+  outfile: '../vscode/out/lsp/lsp.js',
   assets: [
-    { from: [nodeSqlLiteWasm], to: './dist/' },
-    { from: ['./src/run.js'], to: './dist' },
-    { from: ['../../packages/editor-server/src/resources/**'], to: './dist/resources/' },
-    { from: ['../../packages/quarto-core/src/resources/**'], to: './dist/resources/' },
-    { from: ['./dist/**'], to: ['../vscode/out/lsp/'] }],
+    { from: [nodeSqlLiteWasm], to: '../vscode/out/lsp/' },
+    { from: ['./src/run.js'], to: '../vscode/out/lsp' },
+    { from: ['../../packages/editor-server/src/resources/**'], to: '../vscode/out/lsp/resources/' },
+    { from: ['../../packages/quarto-core/src/resources/**'], to: '../vscode/out/lsp/resources/' }
+  ],
   minify: !dev,
   dev
 })


### PR DESCRIPTION
We were building inside `apps/lsp/dist`, then copying over to `apps/vscode/out/lsp`. But the source maps are relative so they were no longer pointing to the correct locations.

Since this is a mono repo, I thought we could just directly build in the vscode's output directory.

With this change, we can set breakpoints inside the LSP. You'll first need to use the "Attach to LSP" launch action once the LSP process has been spawned.