### PR TITLE
Fix logging and configuration watching in LSP

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# This file lists revisions of large-scale formatting/style changes so that
+# they can be excluded from git blame results.
+#
+# To set this file as the default ignore file for git blame, run:
+#   $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Format vscode extention and LSP files consistently (#748)
+a1513effc913e6e59651256d79295da37134dbbf

--- a/apps/lsp/.eslintrc.js
+++ b/apps/lsp/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
   extends: ["custom-server"],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  },
 };

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -83,7 +83,7 @@ function defaultSettings(): Settings {
       colorTheme: 'Dark+'
     },
     quarto: {
-      logLevel: LogLevel.Info,
+      logLevel: LogLevel.Warn,
       path: "",
       mathjax: {
         scale: 1,

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -28,7 +28,7 @@ import {
   ILogger,
   LogLevel
 } from './service';
-import { LogFunctionLogger } from './logging';
+import { Logger } from './logging';
 
 export type ValidateEnabled = 'ignore' | 'warning' | 'error' | 'hint';
 
@@ -141,7 +141,7 @@ export class ConfigurationManager extends Disposable {
   }
 
   public init(logLevel?: string) {
-    const initLogLevel = LogFunctionLogger.parseLogLevel(
+    const initLogLevel = Logger.parseLogLevel(
       logLevel ?? "warn"
     );
 
@@ -164,7 +164,7 @@ export class ConfigurationManager extends Disposable {
         colorTheme: settings.workbench.colorTheme
       },
       quarto: {
-        logLevel: LogFunctionLogger.parseLogLevel(settings.quarto.server.logLevel),
+        logLevel: Logger.parseLogLevel(settings.quarto.server.logLevel),
         path: settings.quarto.path,
         mathjax: {
           scale: settings.quarto.mathjax.scale,

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -28,6 +28,7 @@ import {
   ILogger,
   LogLevel
 } from './service';
+import { LogFunctionLogger } from './logging';
 
 export type ValidateEnabled = 'ignore' | 'warning' | 'error' | 'hint';
 
@@ -36,6 +37,7 @@ export interface Settings {
     readonly colorTheme: string;
   };
   readonly quarto: {
+    readonly logLevel: LogLevel;
     readonly path: string;
     readonly mathjax: {
       readonly scale: number;
@@ -43,10 +45,6 @@ export interface Settings {
     }
   };
   readonly markdown: {
-    readonly server: {
-      readonly log: 'off' | 'debug' | 'trace';
-    };
-
     readonly preferredMdPathExtensionStyle: 'auto' | 'includeExtension' | 'removeExtension';
 
     readonly suggest: {
@@ -85,6 +83,7 @@ function defaultSettings(): Settings {
       colorTheme: 'Dark+'
     },
     quarto: {
+      logLevel: LogLevel.Trace,
       path: "",
       mathjax: {
         scale: 1,
@@ -92,9 +91,6 @@ function defaultSettings(): Settings {
       }
     },
     markdown: {
-      server: {
-        log: 'off'
-      },
       preferredMdPathExtensionStyle: 'auto',
       suggest: {
         paths: {
@@ -154,6 +150,7 @@ export class ConfigurationManager extends Disposable {
         colorTheme: settings.workbench.colorTheme
       },
       quarto: {
+        logLevel: LogFunctionLogger.parseLogLevel(settings.quarto.server.logLevel),
         path: settings.quarto.path,
         mathjax: {
           scale: settings.quarto.mathjax.scale,

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -24,7 +24,8 @@ import {
   IncludeWorkspaceHeaderCompletions,
   LsConfiguration,
   defaultLsConfiguration,
-  PreferredMdPathExtensionStyle
+  PreferredMdPathExtensionStyle,
+  ILogger
 } from './service';
 
 export type ValidateEnabled = 'ignore' | 'warning' | 'error' | 'hint';
@@ -131,9 +132,14 @@ export class ConfigurationManager extends Disposable {
   public readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
 
   private _settings: Settings;
+  private _logger: ILogger;
 
-  constructor(private readonly connection_: Connection) {
+  constructor(
+    private readonly connection_: Connection,
+    logger: ILogger,
+  ) {
     super();
+    this._logger = logger;
     this._settings = defaultSettings();
   }
 
@@ -163,6 +169,7 @@ export class ConfigurationManager extends Disposable {
       undefined
     );
     this.connection_.onDidChangeConfiguration(() => {
+      this._logger.logNotification('didChangeConfiguration');
       this.update();
     });
   }

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -140,16 +140,12 @@ export class ConfigurationManager extends Disposable {
     this._settings = defaultSettings();
   }
 
-  public init(logLevel?: string) {
-    const initLogLevel = Logger.parseLogLevel(
-      logLevel ?? "warn"
-    );
-
+  public init(logLevel: LogLevel) {
     this._settings = {
       ...this._settings,
       quarto: {
         ...this._settings.quarto,
-        logLevel: initLogLevel,
+        logLevel,
       }
     };
   }

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -83,7 +83,7 @@ function defaultSettings(): Settings {
       colorTheme: 'Dark+'
     },
     quarto: {
-      logLevel: LogLevel.Trace,
+      logLevel: LogLevel.Info,
       path: "",
       mathjax: {
         scale: 1,

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -140,6 +140,20 @@ export class ConfigurationManager extends Disposable {
     this._settings = defaultSettings();
   }
 
+  public init(logLevel?: string) {
+    const initLogLevel = LogFunctionLogger.parseLogLevel(
+      logLevel ?? "warn"
+    );
+
+    this._settings = {
+      ...this._settings,
+      quarto: {
+        ...this._settings.quarto,
+        logLevel: initLogLevel,
+      }
+    };
+  }
+
   public async update() {
     this._logger.logTrace('Sending \'configuration\' request');
     const settings = await this.connection_.workspace.getConfiguration();

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -141,7 +141,7 @@ export class ConfigurationManager extends Disposable {
   }
 
   public async update() {
-    this._logger.log(LogLevel.Trace, 'Sending \'configuration\' request');
+    this._logger.logTrace('Sending \'configuration\' request');
     const settings = await this.connection_.workspace.getConfiguration();
 
     this._settings = {

--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -172,8 +172,9 @@ export class ConfigurationManager extends Disposable {
   }
 
   public async subscribe() {
-    // Ignore the settings in parameters, the modern usage is to fetch the settings
-    // when we get this notification
+    // Ignore the settings in parameters, the modern usage is to fetch the
+    // settings when we get this notification. This causes the client to send
+    // any updates for settings under the `quarto` section.
     this.connection_.onDidChangeConfiguration((_params) => {
       this._logger.logNotification('didChangeConfiguration');
       this.update();

--- a/apps/lsp/src/diagnostics.ts
+++ b/apps/lsp/src/diagnostics.ts
@@ -35,7 +35,6 @@ import {
   ILogger,
   IMdLanguageService,
   IWorkspace,
-  LogLevel,
 } from "./service";
 import {
   ConfigurationManager,
@@ -130,7 +129,7 @@ export async function registerDiagnostics(
         FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport
       > => {
 
-        logger.log(LogLevel.Debug, "connection.languages.diagnostics.on", {
+        logger.logDebug("connection.languages.diagnostics.on", {
           document: params.textDocument.uri,
         });
 

--- a/apps/lsp/src/index.ts
+++ b/apps/lsp/src/index.ts
@@ -75,7 +75,11 @@ let mdLs: IMdLanguageService | undefined;
 connection.onInitialize((params: InitializeParams) => {
   // Set log level from initialization options if provided so that we use the
   // expected level as soon as possible
-  configManager.init(params.initializationOptions?.logLevel);
+  const initLogLevel = Logger.parseLogLevel(
+    params.initializationOptions?.logLevel ?? "warn"
+  );
+  logger.init(initLogLevel);
+  configManager.init(initLogLevel);
 
   // We're connected, log messages via LSP
   logger.setConnection(connection);

--- a/apps/lsp/src/index.ts
+++ b/apps/lsp/src/index.ts
@@ -75,6 +75,7 @@ let mdLs: IMdLanguageService | undefined;
 connection.onInitialize((params: InitializeParams) => {
   // We're connected, log messages via LSP
   logger.setConnection(connection);
+  logger.logRequest('initialize');
 
   // alias options and capabilities
   initializationOptions = params.initializationOptions;

--- a/apps/lsp/src/index.ts
+++ b/apps/lsp/src/index.ts
@@ -40,7 +40,7 @@ import { registerCustomMethods } from "./custom";
 import { isWindows, LspConnection } from "core-node";
 import { initQuartoContext, Document, markdownitParser, LspInitializationOptions } from "quarto-core";
 import { ConfigurationManager, lsConfiguration } from "./config";
-import { LogFunctionLogger } from "./logging";
+import { Logger } from "./logging";
 import { languageServiceWorkspace } from "./workspace";
 import { middlewareCapabilities, middlewareRegister } from "./middleware";
 import { createLanguageService, IMdLanguageService } from "./service";
@@ -53,7 +53,7 @@ import { registerDiagnostics } from "./diagnostics";
 const connection = createConnection(ProposedFeatures.all);
 
 // Initialize logger
-const logger = new LogFunctionLogger(console.log.bind(console));
+const logger = new Logger(console.log.bind(console));
 
 // Create text document manager
 const documents: TextDocuments<Document> = new TextDocuments(TextDocument);

--- a/apps/lsp/src/index.ts
+++ b/apps/lsp/src/index.ts
@@ -53,9 +53,7 @@ import { registerDiagnostics } from "./diagnostics";
 const connection = createConnection(ProposedFeatures.all);
 
 // Initialize logger
-const logger = new LogFunctionLogger(
-  console.log.bind(console),
-);
+const logger = new LogFunctionLogger(console.log.bind(console));
 
 // Create text document manager
 const documents: TextDocuments<Document> = new TextDocuments(TextDocument);
@@ -71,10 +69,12 @@ let capabilities: ClientCapabilities | undefined;
 // Initialization options
 let initializationOptions: LspInitializationOptions | undefined;
 
-// Markdowdn language service
+// Markdown language service
 let mdLs: IMdLanguageService | undefined;
 
 connection.onInitialize((params: InitializeParams) => {
+  // We're connected, log messages via LSP
+  logger.setConnection(connection);
 
   // alias options and capabilities
   initializationOptions = params.initializationOptions;

--- a/apps/lsp/src/index.ts
+++ b/apps/lsp/src/index.ts
@@ -73,6 +73,10 @@ let initializationOptions: LspInitializationOptions | undefined;
 let mdLs: IMdLanguageService | undefined;
 
 connection.onInitialize((params: InitializeParams) => {
+  // Set log level from initialization options if provided so that we use the
+  // expected level as soon as possible
+  configManager.init(params.initializationOptions?.logLevel);
+
   // We're connected, log messages via LSP
   logger.setConnection(connection);
   logger.logRequest('initialize');

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -83,16 +83,18 @@ export class LogFunctionLogger extends Disposable implements ILogger {
     switch (logLevel) {
       case 'trace': return LogLevel.Trace;
       case 'debug': return LogLevel.Debug;
-      case 'off':
+      case 'info': return LogLevel.Info;
+      case 'warn': return LogLevel.Warn;
+      case 'error': return LogLevel.Error;
       default:
-        return LogLevel.Off;
+        return LogLevel.Warn;
     }
   }
 
   get level(): LogLevel { return this._logLevel; }
 
   public log(level: LogLevel, message: string, data?: unknown): void {
-    if (this.level < level) {
+    if (level < this.level) {
       return;
     }
 
@@ -112,9 +114,11 @@ export class LogFunctionLogger extends Disposable implements ILogger {
 
   private toLevelLabel(level: LogLevel): string {
     switch (level) {
-      case LogLevel.Off: return 'off';
-      case LogLevel.Debug: return 'debug';
       case LogLevel.Trace: return 'trace';
+      case LogLevel.Debug: return 'debug';
+      case LogLevel.Info: return 'info';
+      case LogLevel.Warn: return 'warn';
+      case LogLevel.Error: return 'error';
     }
   }
 

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -25,8 +25,7 @@ import { ILogger, LogLevel } from "./service";
 import { ConfigurationManager } from './config';
 import { Connection } from 'vscode-languageserver';
 
-export class LogFunctionLogger extends Disposable implements ILogger {
-
+export class Logger extends Disposable implements ILogger {
   private static now(): string {
     const now = new Date();
     return String(now.getUTCHours()).padStart(2, '0')
@@ -66,10 +65,10 @@ export class LogFunctionLogger extends Disposable implements ILogger {
     this._config = config;
 
     this._register(this._config.onDidChangeConfiguration(() => {
-      this._logLevel = LogFunctionLogger.currentLogLevel(this._config!);
+      this._logLevel = Logger.currentLogLevel(this._config!);
     }));
 
-    this._logLevel = LogFunctionLogger.currentLogLevel(this._config);
+    this._logLevel = Logger.currentLogLevel(this._config);
   }
 
   private static currentLogLevel(config: ConfigurationManager): LogLevel {
@@ -100,7 +99,7 @@ export class LogFunctionLogger extends Disposable implements ILogger {
     // See https://github.com/microsoft/vscode-languageserver-node/issues/1116.
     this.appendLine(level, `[lsp-${this.toLevelLabel(level)}] ${message}`);
     if (data) {
-      this.appendLine(level, LogFunctionLogger.data2String(data));
+      this.appendLine(level, Logger.data2String(data));
     }
   }
 

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -149,6 +149,13 @@ export class Logger extends Disposable implements ILogger {
           break;
       }
     } else {
+      // Note that by default, languageserver redirects `console.log` to the
+      // client. However this is only the case with StdIo connections:
+      // https://github.com/microsoft/vscode-languageserver-node/blob/df56e720/server/src/node/main.ts#L262-L264
+      // While we currently only use StdIo to connect the LSP, and so the branch
+      // above to explicitly log via our connection object is not strictly
+      // necessary, it's still better to use our own logger abstraction that we
+      // are in control of.
       this._logFn(value);
     }
   }

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -62,6 +62,7 @@ export class LogFunctionLogger extends Disposable implements ILogger {
 
   setConnection(connection: Connection) {
     this._connection = connection;
+    this.log(LogLevel.Debug, 'LSP is now connected');
   }
 
   setConfigurationManager(config: ConfigurationManager) {
@@ -91,7 +92,7 @@ export class LogFunctionLogger extends Disposable implements ILogger {
       return;
     }
 
-    this.appendLine(`[lsp-${this.toLevelLabel(level)} ${LogFunctionLogger.now()}] ${message}`);
+    this.appendLine(`[lsp-${this.toLevelLabel(level)}] ${message}`);
     if (data) {
       this.appendLine(LogFunctionLogger.data2String(data));
     }

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -47,15 +47,22 @@ export class LogFunctionLogger extends Disposable implements ILogger {
   }
 
   private _logLevel: LogLevel;
+  private _config?: ConfigurationManager;
 
   constructor(
     private readonly _logFn: typeof console.log,
-    private readonly _config: ConfigurationManager,
   ) {
     super();
 
+    // Be verbose during init until we have a chance to get the user configuration
+    this._logLevel = LogLevel.Debug;
+  }
+
+  setConfigurationManager(config: ConfigurationManager) {
+    this._config = config;
+
     this._register(this._config.onDidChangeConfiguration(() => {
-      this._logLevel = LogFunctionLogger.readLogLevel(this._config);
+      this._logLevel = LogFunctionLogger.readLogLevel(this._config!);
     }));
 
     this._logLevel = LogFunctionLogger.readLogLevel(this._config);
@@ -84,11 +91,19 @@ export class LogFunctionLogger extends Disposable implements ILogger {
     }
   }
 
+  public logNotification(method: string) {
+    this.log(LogLevel.Trace, `Got notification: '${method}'`);
+  }
+
+  public logRequest(method: string) {
+    this.log(LogLevel.Trace, `Got request: '${method}'`);
+  }
+
   private toLevelLabel(level: LogLevel): string {
     switch (level) {
-      case LogLevel.Off: return 'Off';
-      case LogLevel.Debug: return 'Debug';
-      case LogLevel.Trace: return 'Trace';
+      case LogLevel.Off: return 'off';
+      case LogLevel.Debug: return 'debug';
+      case LogLevel.Trace: return 'trace';
     }
   }
 

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -69,14 +69,18 @@ export class LogFunctionLogger extends Disposable implements ILogger {
     this._config = config;
 
     this._register(this._config.onDidChangeConfiguration(() => {
-      this._logLevel = LogFunctionLogger.readLogLevel(this._config!);
+      this._logLevel = LogFunctionLogger.currentLogLevel(this._config!);
     }));
 
-    this._logLevel = LogFunctionLogger.readLogLevel(this._config);
+    this._logLevel = LogFunctionLogger.currentLogLevel(this._config);
   }
 
-  private static readLogLevel(config: ConfigurationManager): LogLevel {
-    switch (config.getSettings().markdown.server.log) {
+  private static currentLogLevel(config: ConfigurationManager): LogLevel {
+    return config.getSettings().quarto.logLevel;
+  }
+
+  public static parseLogLevel(logLevel: string): LogLevel {
+    switch (logLevel) {
       case 'trace': return LogLevel.Trace;
       case 'debug': return LogLevel.Debug;
       case 'off':

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -55,9 +55,6 @@ export class LogFunctionLogger extends Disposable implements ILogger {
     private readonly _logFn: typeof console.log,
   ) {
     super();
-
-    // Be verbose during init until we have a chance to get the user configuration
-    this._logLevel = LogLevel.Debug;
   }
 
   setConnection(connection: Connection) {

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -62,7 +62,7 @@ export class LogFunctionLogger extends Disposable implements ILogger {
 
   setConnection(connection: Connection) {
     this._connection = connection;
-    this.log(LogLevel.Debug, 'LSP is now connected');
+    this.logInfo('LSP is now connected');
   }
 
   setConfigurationManager(config: ConfigurationManager) {
@@ -104,12 +104,27 @@ export class LogFunctionLogger extends Disposable implements ILogger {
     }
   }
 
-  public logNotification(method: string) {
-    this.log(LogLevel.Trace, `Got notification: '${method}'`);
+  public logTrace(message: string, data?: Record<string, unknown>): void {
+    this.log(LogLevel.Trace, message, data);
+  }
+  public logDebug(message: string, data?: Record<string, unknown>): void {
+    this.log(LogLevel.Debug, message, data);
+  }
+  public logInfo(message: string, data?: Record<string, unknown>): void {
+    this.log(LogLevel.Info, message, data);
+  }
+  public logWarn(message: string, data?: Record<string, unknown>): void {
+    this.log(LogLevel.Warn, message, data);
+  }
+  public logError(message: string, data?: Record<string, unknown>): void {
+    this.log(LogLevel.Error, message, data);
   }
 
-  public logRequest(method: string) {
-    this.log(LogLevel.Trace, `Got request: '${method}'`);
+  public logNotification(method: string, data?: Record<string, unknown>) {
+    this.logTrace(`Got notification: '${method}'`, data);
+  }
+  public logRequest(method: string, data?: Record<string, unknown>) {
+    this.logTrace(`Got request: '${method}'`, data);
   }
 
   private toLevelLabel(level: LogLevel): string {

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -46,7 +46,7 @@ export class Logger extends Disposable implements ILogger {
     return JSON.stringify(data, undefined, 2);
   }
 
-  private _logLevel: LogLevel;
+  private _logLevel = LogLevel.Warn;
   private _connection?: Connection;
   private _config?: ConfigurationManager;
 
@@ -54,6 +54,10 @@ export class Logger extends Disposable implements ILogger {
     private readonly _logFn: typeof console.log,
   ) {
     super();
+  }
+
+  init(logLevel: LogLevel): void {
+    this._logLevel = logLevel;
   }
 
   setConnection(connection: Connection) {

--- a/apps/lsp/src/logging.ts
+++ b/apps/lsp/src/logging.ts
@@ -143,18 +143,8 @@ export class LogFunctionLogger extends Disposable implements ILogger {
       // The log level is not currently forwarded to our `LogOutputChannel` on
       // the client side. We'll need to update to languageclient 10.x for this,
       // see https://github.com/microsoft/vscode-languageserver-node/issues/1116.
+      // So just emit everything via `log` for now.
       switch (level) {
-        case LogLevel.Error:
-          this._connection.console.error(value);
-          break;
-        case LogLevel.Warn:
-          this._connection.console.warn(value);
-          break;
-        case LogLevel.Info:
-          this._connection.console.info(value);
-          break;
-        case LogLevel.Debug:
-        case LogLevel.Trace:
         default:
           this._connection.console.log(value);
           break;

--- a/apps/lsp/src/service/config.ts
+++ b/apps/lsp/src/service/config.ts
@@ -17,6 +17,7 @@
 import * as picomatch from 'picomatch';
 import { URI } from 'vscode-uri';
 import { MathjaxSupportedExtension } from 'editor-types';
+import { LogLevel } from './logging';
 
 /**
  * Preferred style for file paths to {@link markdownFileExtensions markdown files}.
@@ -39,6 +40,8 @@ export enum PreferredMdPathExtensionStyle {
 }
 
 export interface LsConfiguration {
+  readonly logLevel: LogLevel;
+
   /**
    * List of file extensions should be considered markdown.
    *
@@ -73,15 +76,15 @@ export interface LsConfiguration {
 
   readonly includeWorkspaceHeaderCompletions: 'never' | 'onSingleOrDoubleHash' | 'onDoubleHash';
 
-  readonly colorTheme: "light" | "dark";
+  readonly colorTheme: 'light' | 'dark';
   readonly mathjaxScale: number;
   readonly mathjaxExtensions: readonly MathjaxSupportedExtension[];
-
 }
 
 export const defaultMarkdownFileExtension = 'qmd';
 
 const defaultConfig: LsConfiguration = {
+  logLevel: LogLevel.Trace,
   markdownFileExtensions: [defaultMarkdownFileExtension, 'md'],
   knownLinkedToFileExtensions: [
     'jpg',
@@ -104,7 +107,7 @@ const defaultConfig: LsConfiguration = {
     "**/env/**"
   ],
   includeWorkspaceHeaderCompletions: 'never',
-  colorTheme: "light",
+  colorTheme: 'light',
   mathjaxScale: 1,
   mathjaxExtensions: []
 };

--- a/apps/lsp/src/service/logging.ts
+++ b/apps/lsp/src/service/logging.ts
@@ -45,4 +45,16 @@ export interface ILogger {
    * @param data Additional information about what is being logged.
    */
   log(level: LogLevel, message: string, data?: Record<string, unknown>): void;
+
+  /**
+   * Log notification at Trace level.
+   * @param method Message type name.
+   */
+  logNotification(method: string): void;
+
+  /**
+   * Log request at Trace level.
+   * @param method Message type name.
+   */
+  logRequest(method: string): void;
 }

--- a/apps/lsp/src/service/logging.ts
+++ b/apps/lsp/src/service/logging.ts
@@ -52,15 +52,21 @@ export interface ILogger {
    */
   log(level: LogLevel, message: string, data?: Record<string, unknown>): void;
 
+  logTrace(message: string, data?: Record<string, unknown>): void;
+  logDebug(message: string, data?: Record<string, unknown>): void;
+  logInfo(message: string, data?: Record<string, unknown>): void;
+  logWarn(message: string, data?: Record<string, unknown>): void;
+  logError(message: string, data?: Record<string, unknown>): void;
+
   /**
    * Log notification at Trace level.
    * @param method Message type name.
    */
-  logNotification(method: string): void;
+  logNotification(method: string, data?: Record<string, unknown>): void;
 
   /**
    * Log request at Trace level.
    * @param method Message type name.
    */
-  logRequest(method: string): void;
+  logRequest(method: string, data?: Record<string, unknown>): void;
 }

--- a/apps/lsp/src/service/logging.ts
+++ b/apps/lsp/src/service/logging.ts
@@ -18,14 +18,20 @@
  * The level of verbosity that the language service logs at.
  */
 export enum LogLevel {
-  /** Disable logging */
-  Off,
+  /** Log extremely verbose info about language server operation, such as calls into the file system */
+  Trace,
 
   /** Log verbose info about language server operation, such as when references are re-computed for a md file. */
   Debug,
 
-  /** Log extremely verbose info about language server operation, such as calls into the file system */
-  Trace,
+  /** Informational messages that highlight the progress of the application at coarse-grained level. */
+  Info,
+
+  /** Potentially harmful situations which still allow the application to continue running. */
+  Warn,
+
+  /** Error events that might still allow the application to continue running. */
+  Error,
 }
 
 /**

--- a/apps/lsp/src/service/providers/diagnostics.ts
+++ b/apps/lsp/src/service/providers/diagnostics.ts
@@ -210,7 +210,7 @@ export class DiagnosticComputer {
     readonly links: readonly MdLink[];
     readonly statCache: ResourceMap<{ readonly exists: boolean }>;
   }> {
-    this.#logger.log(LogLevel.Debug, 'DiagnosticComputer.compute', { document: doc.uri, version: doc.version });
+    this.#logger.logDebug('DiagnosticComputer.compute', { document: doc.uri, version: doc.version });
 
     const { links, definitions } = await this.#linkProvider.getLinks(doc);
     const statCache = new ResourceMap<{ readonly exists: boolean }>();
@@ -235,7 +235,7 @@ export class DiagnosticComputer {
       ])).flat());
     }
 
-    this.#logger.log(LogLevel.Trace, 'DiagnosticComputer.compute finished', { document: doc.uri, version: doc.version, diagnostics });
+    this.#logger.logTrace('DiagnosticComputer.compute finished', { document: doc.uri, version: doc.version, diagnostics });
 
     return {
       links: links,
@@ -612,7 +612,7 @@ class FileLinkState extends Disposable {
   }
 
   #onLinkedResourceChanged(resource: URI, exists: boolean) {
-    this.#logger.log(LogLevel.Trace, 'FileLinkState.onLinkedResourceChanged', { resource, exists });
+    this.#logger.logTrace('FileLinkState.onLinkedResourceChanged', { resource, exists });
 
     const entry = this.#linkedToFile.get(resource);
     if (entry) {
@@ -650,7 +650,7 @@ export class DiagnosticsManager extends Disposable implements IPullDiagnosticsMa
     this.#linkWatcher = this._register(linkWatcher);
 
     this._register(this.#linkWatcher.onDidChangeLinkedToFile(e => {
-      logger.log(LogLevel.Trace, 'DiagnosticsManager.onDidChangeLinkedToFile', { resource: e.changedResource });
+      logger.logTrace('DiagnosticsManager.onDidChangeLinkedToFile', { resource: e.changedResource });
 
       this.#onLinkedToFileChanged.fire({
         changedResource: e.changedResource,

--- a/apps/lsp/src/service/providers/document-links.ts
+++ b/apps/lsp/src/service/providers/document-links.ts
@@ -779,7 +779,7 @@ export class MdLinkProvider extends Disposable {
 
     this.#linkComputer = new MdLinkComputer(parser, this.#workspace);
     this.#linkCache = this._register(new MdDocumentInfoCache(this.#workspace, async (doc, token) => {
-      logger.log(LogLevel.Debug, 'LinkProvider.compute', { document: doc.uri, version: doc.version });
+      logger.logDebug('LinkProvider.compute', { document: doc.uri, version: doc.version });
 
       const links = await this.#linkComputer.getAllLinks(doc, token);
       return {

--- a/apps/lsp/src/service/providers/document-symbols.ts
+++ b/apps/lsp/src/service/providers/document-symbols.ts
@@ -48,7 +48,7 @@ export class MdDocumentSymbolProvider {
   }
 
   public async provideDocumentSymbols(document: Document, options: ProvideDocumentSymbolOptions, token: CancellationToken): Promise<lsp.DocumentSymbol[]> {
-    this.#logger.log(LogLevel.Debug, 'DocumentSymbolProvider.provideDocumentSymbols', { document: document.uri, version: document.version });
+    this.#logger.logDebug('DocumentSymbolProvider.provideDocumentSymbols', { document: document.uri, version: document.version });
 
     if (token.isCancellationRequested) {
       return [];

--- a/apps/lsp/src/service/providers/folding.ts
+++ b/apps/lsp/src/service/providers/folding.ts
@@ -45,7 +45,7 @@ export class MdFoldingProvider {
   }
 
   public async provideFoldingRanges(document: Document, token: CancellationToken): Promise<lsp.FoldingRange[]> {
-    this.#logger.log(LogLevel.Debug, 'MdFoldingProvider.provideFoldingRanges', { document: document.uri, version: document.version });
+    this.#logger.logDebug('MdFoldingProvider.provideFoldingRanges', { document: document.uri, version: document.version });
 
     if (token.isCancellationRequested) {
       return [];

--- a/apps/lsp/src/service/providers/references.ts
+++ b/apps/lsp/src/service/providers/references.ts
@@ -119,7 +119,7 @@ export class MdReferencesProvider extends Disposable {
   }
 
   public async getReferencesAtPosition(document: Document, position: lsp.Position, token: CancellationToken): Promise<MdReference[]> {
-    this.#logger.log(LogLevel.Debug, 'ReferencesProvider.getReferencesAtPosition', { document: document.uri, version: document.version });
+    this.#logger.logDebug('ReferencesProvider.getReferencesAtPosition', { document: document.uri, version: document.version });
 
     const toc = await this.#tocProvider.getForDocument(document);
     if (token.isCancellationRequested) {
@@ -135,7 +135,7 @@ export class MdReferencesProvider extends Disposable {
   }
 
   public async getReferencesToFileInWorkspace(resource: URI, token: CancellationToken): Promise<MdReference[]> {
-    this.#logger.log(LogLevel.Debug, 'ReferencesProvider.getAllReferencesToFileInWorkspace', { resource });
+    this.#logger.logDebug('ReferencesProvider.getAllReferencesToFileInWorkspace', { resource });
 
     if (token.isCancellationRequested) {
       return [];

--- a/apps/lsp/src/service/providers/smart-select.ts
+++ b/apps/lsp/src/service/providers/smart-select.ts
@@ -41,7 +41,7 @@ export class MdSelectionRangeProvider {
   }
 
   public async provideSelectionRanges(document: Document, positions: readonly Position[], token: CancellationToken): Promise<lsp.SelectionRange[] | undefined> {
-    this.#logger.log(LogLevel.Debug, 'MdSelectionRangeProvider.provideSelectionRanges', { document: document.uri, version: document.version });
+    this.#logger.logDebug('MdSelectionRangeProvider.provideSelectionRanges', { document: document.uri, version: document.version });
 
     if (token.isCancellationRequested) {
       return undefined;

--- a/apps/lsp/src/service/toc.ts
+++ b/apps/lsp/src/service/toc.ts
@@ -299,7 +299,7 @@ export class MdTableOfContentsProvider extends Disposable {
     this.#logger = logger;
 
     this.#cache = this._register(new MdDocumentInfoCache<TableOfContents>(workspace, (doc, token) => {
-      this.#logger.log(LogLevel.Debug, 'TableOfContentsProvider.create', { document: doc.uri, version: doc.version });
+      this.#logger.logDebug('TableOfContentsProvider.create', { document: doc.uri, version: doc.version });
       return TableOfContents.create(parser, doc, token);
     }));
   }

--- a/apps/lsp/src/workspace.ts
+++ b/apps/lsp/src/workspace.ts
@@ -33,7 +33,6 @@ import { Document, isQuartoDoc } from "quarto-core";
 import {
   FileStat,
   ILogger,
-  LogLevel,
   LsConfiguration,
   IWorkspace,
   IWorkspaceWithWatching,
@@ -98,7 +97,7 @@ export function languageServiceWorkspace(
   const onDidDeleteMarkdownDocument = new Emitter<URI>();
 
   const doDeleteDocument = (uri: URI) => {
-    logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.deleteDocument', { document: uri.toString() });
+    logger.logTrace('VsCodeClientWorkspace.deleteDocument', { document: uri.toString() });
     documentCache.delete(uri);
     onDidDeleteMarkdownDocument.fire(uri);
   }
@@ -107,7 +106,7 @@ export function languageServiceWorkspace(
     if (!isRelevantMarkdownDocument(e.document)) {
       return;
     }
-    logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.TextDocument.onDidOpen', { document: e.document.uri });
+    logger.logNotification('onDidOpen', { document: e.document.uri });
 
     const uri = URI.parse(e.document.uri);
     const doc = documentCache.get(uri);
@@ -132,7 +131,7 @@ export function languageServiceWorkspace(
       return;
     }
 
-    logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.TextDocument.onDidChanceContent', { document: e.document.uri });
+    logger.logNotification('onDidChangeContent', { document: e.document.uri });
 
     const uri = URI.parse(e.document.uri);
     const entry = documentCache.get(uri);
@@ -147,7 +146,7 @@ export function languageServiceWorkspace(
       return;
     }
 
-    logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.TextDocument.onDidClose', { document: e.document.uri });
+    logger.logNotification('onDidClose', { document: e.document.uri });
 
     const uri = URI.parse(e.document.uri);
     const doc = documentCache.get(uri);
@@ -254,7 +253,7 @@ export function languageServiceWorkspace(
     },
 
     async stat(resource: URI): Promise<FileStat | undefined> {
-      logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.stat', { resource: resource.toString() });
+      logger.logTrace('VsCodeClientWorkspace.stat', { resource: resource.toString() });
       if (documentCache.has(resource)) {
         return { isDirectory: false };
       }
@@ -262,7 +261,7 @@ export function languageServiceWorkspace(
     },
 
     async readDirectory(resource: URI): Promise<Iterable<readonly [string, FileStat]>> {
-      logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.readDirectory', { resource: resource.toString() });
+      logger.logTrace('VsCodeClientWorkspace.readDirectory', { resource: resource.toString() });
       const result = await fspromises.readdir(resource.fsPath, { withFileTypes: true });
       return result.map(value => [value.name, { isDirectory: value.isDirectory() }]);
     },
@@ -313,7 +312,7 @@ export function languageServiceWorkspace(
       // keep document cache up to date and notify clients
       for (const change of changes) {
         const resource = URI.parse(change.uri);
-        logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.onDidChangeWatchedFiles', { type: change.type, resource: resource.toString() });
+        logger.logTrace('VsCodeClientWorkspace.onDidChangeWatchedFiles', { type: change.type, resource: resource.toString() });
         switch (change.type) {
           case FileChangeType.Changed: {
             const entry = documentCache.get(resource);
@@ -356,7 +355,7 @@ export function languageServiceWorkspace(
     const fsWorkspace: IWorkspaceWithWatching = {
       ...workspace,
       watchFile(resource, options) {
-        logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.watchFile', { resource: resource.toString() });
+        logger.logTrace('VsCodeClientWorkspace.watchFile', { resource: resource.toString() });
 
         const entry = {
           resource,
@@ -371,7 +370,7 @@ export function languageServiceWorkspace(
           onDidChange: entry.onDidChange.event,
           onDidDelete: entry.onDidDelete.event,
           dispose: () => {
-            logger.log(LogLevel.Trace, 'VsCodeClientWorkspace.disposeWatcher', { resource: resource.toString() });
+            logger.logTrace('VsCodeClientWorkspace.disposeWatcher', { resource: resource.toString() });
             watchers.delete(entry.resource.toString());
           }
         };

--- a/apps/vscode/justfile
+++ b/apps/vscode/justfile
@@ -1,0 +1,8 @@
+install:
+  rm -rf *.vsix && vsce package && code --install-extension *.vsix && positron --install-extension *.vsix
+
+install-vscode:
+  rm -rf *.vsix && vsce package && code --install-extension *.vsix
+
+install-positron:
+  rm -rf *.vsix && vsce package && positron --install-extension *.vsix

--- a/apps/vscode/justfile
+++ b/apps/vscode/justfile
@@ -1,8 +1,0 @@
-install:
-  rm -rf *.vsix && vsce package && code --install-extension *.vsix && positron --install-extension *.vsix
-
-install-vscode:
-  rm -rf *.vsix && vsce package && code --install-extension *.vsix
-
-install-positron:
-  rm -rf *.vsix && vsce package && positron --install-extension *.vsix

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1314,7 +1314,9 @@
           "enum": [
             "trace",
             "debug",
-            "off"
+            "info",
+            "warn",
+            "error"
           ],
           "markdownDescription": "Log level for the Quarto language server."
         }

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1306,6 +1306,17 @@
             "type": "string"
           },
           "uniqueItems": true
+        },
+        "quarto.server.logLevel": {
+          "scope": "window",
+          "type": "string",
+          "default": "warn",
+          "enum": [
+            "trace",
+            "debug",
+            "off"
+          ],
+          "markdownDescription": "Log level for the Quarto language server."
         }
       }
     },

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -147,17 +147,6 @@ export async function activateLsp(
     clientOptions
   );
 
-  // Notify LSP of quarto setting changes
-  context.subscriptions.push(workspace.onDidChangeConfiguration(e => {
-    if (client.state !== State.Running) {
-      return;
-    }
-
-    if (e.affectsConfiguration("quarto")) {
-      client.sendNotification("workspace/didChangeConfiguration", {});
-    }
-  }));
-
   // return once the server is running
   return new Promise<LanguageClient>((resolve, reject) => {
 

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -117,7 +117,8 @@ export async function activateLsp(
 
   // create client options
   const initializationOptions: LspInitializationOptions = {
-    quartoBinPath: quartoContext.binPath
+    quartoBinPath: quartoContext.binPath,
+    logLevel: config.get("server.logLevel"),
   };
 
   const documentSelectorPattern = semver.gte(quartoContext.version, "1.6.24") ?

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -146,6 +146,17 @@ export async function activateLsp(
     clientOptions
   );
 
+  // Notify LSP of quarto setting changes
+  context.subscriptions.push(workspace.onDidChangeConfiguration(e => {
+    if (client.state !== State.Running) {
+      return;
+    }
+
+    if (e.affectsConfiguration("quarto")) {
+      client.sendNotification("workspace/didChangeConfiguration", {});
+    }
+  }));
+
   // return once the server is running
   return new Promise<LanguageClient>((resolve, reject) => {
 

--- a/packages/quarto-core/src/lsp.ts
+++ b/packages/quarto-core/src/lsp.ts
@@ -15,4 +15,5 @@
 
 export interface LspInitializationOptions {
   quartoBinPath?: string;
+  logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
 }


### PR DESCRIPTION
The LSP is currently not emitting any log messages because:

- The default log level is 'off'
- We're not watching any log level setting so it can't be changed

I've also noticed the following issues:

- The log level setting on the LSP side is `markdown.server.log` which is a remnant from copying over the Markdown LSP.

- The LSP log levels are currently "off", "debug", and "trace". I think we're missing "warn" and "error" for important user messages, and "info" for benign user messages. If we have these, then we should probably remove "off" and have the least verbose level set to "error" (this is what we do in Ark for instance).

Main fixes in this PR:

- Move log level setting to `quarto.server.logLevel`. Since it's now a `quarto` setting, we get notified when it changes.
- Handle `logLevel` change events on the server side so the LSP can immediately react to log level changes.
- Also send `logLevel` in `initializationOptions` so the LSP can use the level set by the user as early as possible.

Adjacent fixes and cleanups:

- Refactor log levels to take error, warn, info, debug, and trace levels.
  Set default trace level to `warn`.
- Add `log()` wrappers like `logError()`, `logWarn()`, etc, as well as `logNotification()` and `logRequest()` to log at trace level received LSP messages.
- Call the latter in message handlers to increase the coverage of LSP events at trace level, which is very valuable for debugging.

- Minor: The logger class currently emits messages via `console.log`, which `languageserver` redirects to the client when the connection is of type StdIo (see // https://github.com/microsoft/vscode-languageserver-node/blob/df56e720/server/src/node/main.ts#L262-L264). I changed this to explicitly send messages via our connection object instead, which should also work if someone needs to connect to the LSP via TCP. This will also allow us to use more accurate LSP loggers once we switch to languageclient 10 which will support `LogChannelOutput` on the client side (see https://github.com/microsoft/vscode-languageserver-node/issues/1116).

