### PR TITLE
Exclude section headers from workspace symbols in R packages

### DIFF
--- a/apps/lsp/src/config.ts
+++ b/apps/lsp/src/config.ts
@@ -43,6 +43,9 @@ export interface Settings {
       readonly scale: number;
       readonly extensions: MathjaxSupportedExtension[];
     }
+    readonly symbols: {
+      readonly exportToWorkspace: 'default' | 'all' | 'none';
+    };
   };
   readonly markdown: {
     readonly preferredMdPathExtensionStyle: 'auto' | 'includeExtension' | 'removeExtension';
@@ -88,6 +91,9 @@ function defaultSettings(): Settings {
       mathjax: {
         scale: 1,
         extensions: []
+      },
+      symbols: {
+        exportToWorkspace: 'all'
       }
     },
     markdown: {
@@ -169,6 +175,9 @@ export class ConfigurationManager extends Disposable {
         mathjax: {
           scale: settings.quarto.mathjax.scale,
           extensions: settings.quarto.mathjax.extensions
+        },
+        symbols: {
+          exportToWorkspace: settings.quarto.symbols.exportToWorkspace
         }
       }
     };
@@ -228,11 +237,12 @@ export function lsConfiguration(configManager: ConfigurationManager): LsConfigur
     },
     get mathjaxExtensions(): readonly MathjaxSupportedExtension[] {
       return configManager.getSettings().quarto.mathjax.extensions;
+    },
+    get exportSymbolsToWorkspace(): 'default' | 'all' | 'none' {
+      return configManager.getSettings().quarto.symbols.exportToWorkspace;
     }
   }
 }
-
-
 
 export function getDiagnosticsOptions(configManager: ConfigurationManager): DiagnosticOptions {
   const settings = configManager.getSettings();

--- a/apps/lsp/src/r-utils.ts
+++ b/apps/lsp/src/r-utils.ts
@@ -1,0 +1,27 @@
+/*
+ * r-utils.ts
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { isRPackage as isRPackageImpl } from "@utils/r-utils";
+import { IWorkspace } from './service';
+
+// Version that selects workspace folder
+export async function isRPackage(workspace: IWorkspace): Promise<boolean> {
+  if (workspace.workspaceFolders === undefined) {
+    return false;
+  }
+
+  const folderUri = workspace.workspaceFolders[0];
+  return isRPackageImpl(folderUri);
+}

--- a/apps/lsp/src/service/config.ts
+++ b/apps/lsp/src/service/config.ts
@@ -79,6 +79,7 @@ export interface LsConfiguration {
   readonly colorTheme: 'light' | 'dark';
   readonly mathjaxScale: number;
   readonly mathjaxExtensions: readonly MathjaxSupportedExtension[];
+  readonly exportSymbolsToWorkspace: 'default' | 'all' | 'none';
 }
 
 export const defaultMarkdownFileExtension = 'qmd';
@@ -109,7 +110,8 @@ const defaultConfig: LsConfiguration = {
   includeWorkspaceHeaderCompletions: 'never',
   colorTheme: 'light',
   mathjaxScale: 1,
-  mathjaxExtensions: []
+  mathjaxExtensions: [],
+  exportSymbolsToWorkspace: 'all'
 };
 
 export function defaultLsConfiguration(): LsConfiguration {

--- a/apps/lsp/src/service/index.ts
+++ b/apps/lsp/src/service/index.ts
@@ -209,7 +209,7 @@ export function createLanguageService(init: LanguageServiceInitialization): IMdL
   const diagnosticOnSaveComputer = new DiagnosticOnSaveComputer(init.quarto);
   const diagnosticsComputer = new DiagnosticComputer(config, init.workspace, linkProvider, tocProvider, logger);
   const docSymbolProvider = new MdDocumentSymbolProvider(tocProvider, linkProvider, logger);
-  const workspaceSymbolProvider = new MdWorkspaceSymbolProvider(init.workspace, docSymbolProvider);
+  const workspaceSymbolProvider = new MdWorkspaceSymbolProvider(init.workspace, init.config, docSymbolProvider);
   const documentHighlightProvider = new MdDocumentHighlightProvider(config, tocProvider, linkProvider);
 
   return Object.freeze<IMdLanguageService>({

--- a/apps/lsp/src/service/providers/workspace-symbols.ts
+++ b/apps/lsp/src/service/providers/workspace-symbols.ts
@@ -14,8 +14,6 @@
  *
  */
 
-import * as fs from 'fs';
-import { Utils } from 'vscode-uri';
 import { CancellationToken } from 'vscode-languageserver';
 import * as lsp from 'vscode-languageserver-types';
 import { Disposable } from 'core';
@@ -24,6 +22,7 @@ import { IWorkspace } from '../workspace';
 import { MdWorkspaceInfoCache } from '../workspace-cache';
 import { MdDocumentSymbolProvider } from './document-symbols';
 import { LsConfiguration } from '../config';
+import { isRPackage } from '../../r-utils';
 
 export class MdWorkspaceSymbolProvider extends Disposable {
   readonly #config: LsConfiguration;
@@ -52,7 +51,7 @@ export class MdWorkspaceSymbolProvider extends Disposable {
 
     switch (this.#config.exportSymbolsToWorkspace) {
       case 'all': break;
-      case 'default': if (shouldExportSymbolsToWorkspace(this.#workspace)) return []; else break;
+      case 'default': if (await shouldExportSymbolsToWorkspace(this.#workspace)) return []; else break;
       case 'none': return [];
     }
 
@@ -88,16 +87,6 @@ export class MdWorkspaceSymbolProvider extends Disposable {
   }
 }
 
-function shouldExportSymbolsToWorkspace(workspace: IWorkspace): boolean {
-  return isRPackage(workspace);
-}
-
-function isRPackage(workspace: IWorkspace): boolean {
-  if (workspace.workspaceFolders === undefined) {
-    return false;
-  }
-
-  const projectPath = workspace.workspaceFolders[0];
-  const descPath = Utils.joinPath(projectPath, 'DESCRIPTION');
-  return fs.existsSync(descPath.fsPath);
+async function shouldExportSymbolsToWorkspace(workspace: IWorkspace): Promise<boolean> {
+  return await isRPackage(workspace);
 }

--- a/apps/lsp/tsconfig.json
+++ b/apps/lsp/tsconfig.json
@@ -3,9 +3,11 @@
     "lib": ["ES2020"],
     "module": "CommonJS",
     "outDir": "./dist",
-    "rootDir": "./src",
     "sourceMap": true,
     "resolveJsonModule": true,
+    "paths": {
+      "@utils/*": ["../utils/*"]
+    }
   },
   "exclude": ["node_modules"],
   "extends": "tsconfig/base.json",

--- a/apps/utils/r-utils.ts
+++ b/apps/utils/r-utils.ts
@@ -1,0 +1,63 @@
+/*
+ * r-utils.ts
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { URI } from 'vscode-uri';
+
+/**
+ * Checks if the given folder contains an R package.
+ *
+ * Determined by:
+ * - Presence of a `DESCRIPTION` file.
+ * - Presence of `Package:` field.
+ * - Presence of `Type: package` field and value.
+ *
+ * The fields are checked to disambiguate real packages from book repositories using a `DESCRIPTION` file.
+ *
+ * @param folderPath Folder to check for a `DESCRIPTION` file.
+ */
+export async function isRPackage(folderUri: URI): Promise<boolean> {
+  // We don't currently support non-file schemes
+  if (folderUri.scheme !== 'file') {
+    return false;
+  }
+
+  const descriptionLines = await parseRPackageDescription(folderUri.fsPath);
+  if (!descriptionLines) {
+    return false;
+  }
+
+  const packageLines = descriptionLines.filter(line => line.startsWith('Package:'));
+  const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
+
+  const typeIsPackage = (typeLines.length > 0
+    ? typeLines[0].toLowerCase().includes('package')
+    : false);
+  const typeIsPackageOrMissing = typeLines.length === 0 || typeIsPackage;
+
+  return packageLines.length > 0 && typeIsPackageOrMissing;
+}
+
+async function parseRPackageDescription(folderPath: string): Promise<string[]> {
+  const filePath = path.join(folderPath, 'DESCRIPTION');
+
+  try {
+    const descriptionText = await fs.readFile(filePath, 'utf8');
+    return descriptionText.split(/\r?\n/);
+  } catch {
+    return [''];
+  }
+}

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1319,6 +1319,17 @@
             "error"
           ],
           "markdownDescription": "Log level for the Quarto language server."
+        },
+        "quarto.symbols.exportToWorkspace": {
+          "type": "string",
+          "enum": ["default", "all", "none"],
+          "enumDescriptions": [
+            "Depends on the project type: `\"none\"` in R packages, `\"all\"` otherwise.",
+            "",
+            ""
+          ],
+          "default": "default",
+          "description": "Whether Markdown elements like section headers are included in workspace symbol search."
         }
       }
     },

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -13,6 +13,7 @@
  *
  */
 
+import * as fs from "fs";
 import * as path from "path";
 import {
   ExtensionContext,

--- a/apps/vscode/src/providers/preview/preview-util.ts
+++ b/apps/vscode/src/providers/preview/preview-util.ts
@@ -60,34 +60,6 @@ export function isQuartoShinyKnitrDoc(
 
 }
 
-export async function isRPackage(): Promise<boolean> {
-  const descriptionLines = await parseRPackageDescription();
-  if (!descriptionLines) {
-    return false;
-  }
-  const packageLines = descriptionLines.filter(line => line.startsWith('Package:'));
-  const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
-  const typeIsPackage = (typeLines.length > 0
-    ? typeLines[0].toLowerCase().includes('package')
-    : false);
-  const typeIsPackageOrMissing = typeLines.length === 0 || typeIsPackage;
-  return packageLines.length > 0 && typeIsPackageOrMissing;
-}
-
-async function parseRPackageDescription(): Promise<string[]> {
-  if (vscode.workspace.workspaceFolders !== undefined) {
-    const folderUri = vscode.workspace.workspaceFolders[0].uri;
-    const fileUri = vscode.Uri.joinPath(folderUri, 'DESCRIPTION');
-    try {
-      const bytes = await vscode.workspace.fs.readFile(fileUri);
-      const descriptionText = Buffer.from(bytes).toString('utf8');
-      const descriptionLines = descriptionText.split(/(\r?\n)/);
-      return descriptionLines;
-    } catch { }
-  }
-  return [''];
-}
-
 export async function renderOnSave(engine: MarkdownEngine, document: TextDocument) {
   // if its a notebook and we don't have a save hook for notebooks then don't
   // allow renderOnSave (b/c we can't detect the saves)

--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -74,7 +74,6 @@ import {
   haveNotebookSaveEvents,
   isQuartoShinyDoc,
   isQuartoShinyKnitrDoc,
-  isRPackage,
   renderOnSave,
 } from "./preview-util";
 
@@ -88,6 +87,7 @@ import {
   yamlErrorLocation,
 } from "./preview-errors";
 import { ExtensionHost } from "../../host";
+import { isRPackage } from "../../r-utils";
 
 tmp.setGracefulCleanup();
 

--- a/apps/vscode/src/r-utils.ts
+++ b/apps/vscode/src/r-utils.ts
@@ -1,0 +1,29 @@
+/*
+ * r-utils.ts
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import * as vscode from 'vscode';
+import { isRPackage as isRPackageImpl } from "@utils/r-utils";
+
+// Version that selects workspace folder
+export async function isRPackage(): Promise<boolean> {
+  if (vscode.workspace.workspaceFolders === undefined) {
+    return false;
+  }
+
+  // Pick first workspace
+  const workspaceFolder = vscode.workspace.workspaceFolders[0];
+
+  return isRPackageImpl(workspaceFolder.uri);
+}

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -5,7 +5,11 @@
     "outDir": "out",
     "lib": ["ES2021"],
     "sourceMap": true,
-    "strict": true /* enable all strict type-checking options */
+    "strict": true,
+    "paths": {
+      "@utils/*": ["../utils/*"]
+    }
+    /* enable all strict type-checking options */
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8401

Once activated, the Quarto extension currently scans all md files and exports section headers to workspace symbols. While great generally, this can get in the way of the dev workflow in R packages.

R packages may include a variety of md files:

- Snapshot files: https://github.com/tidyverse/ellmer/tree/main/tests/testthat/_snaps
- Documentation: https://github.com/r-lib/rlang/tree/main/man/rmd

This causes Quarto to flood workspace symbols with headers that are mostly irrelevant for package development:

https://github.com/user-attachments/assets/a0269da3-68b5-44b2-b10c-ccae9a9196b3


I think by default (without any user configuration), headers shouldn't be exported as workspace symbols in R packages. But we need to preserve the existing behaviour for other projects.

To fix this, this PR:

- Introduces a new setting `quarto.symbols.exportToWorkspace`, with values `"default"`, `"all"`, or `"none"`. We need an enum with a default case instead of a boolean to provide the default behaviour that depends on the project type. The other two values allow hardcoding the behaviour in a project.

- When set to `"default"`, the LSP detects if the project is an R package.

  While the LSP would ideally be agnostic regarding the project type, having a customisation mechanism for extensions to set the default behaviour for a project would be complicated and require conflict solving if two extensions try to handle the same project.

- We already have a tool to detect R packages in the extension module (thanks to @juliasilge to have let me know!). It's a bit complicated because we need to parse the project's DESCRIPTION file if present, so I think we need to use the same implementation in both the LSP and extension. I pulled it up one level in `apps/utils`. To keep things light I didn't make it a full node module.

- The tool in `apps/utils` take a folder path. Then two wrappers in `apps/lsp` and `apps/vscode` are in charge of unpacking the relevant workspace folder (via different APIs specific to the LSP and extension) and calling the util.


### QA Notes

Create an R package with markdown files and make sure the Quarto extension is activated (it activates when navigating to an R file). Look for workspace symbols (cmd T, or `#` prefix in command palette). The markdown headers shouldn't be included.

In a project that's not an R package, they should be included.

In the R package you can opt into including the headers via `quarto.symbols.exportToWorkspace`. In the regular project you can disable them. The setting should immediately apply (at the next request).
