### PR TITLE
Prototype of getting active vscode theme in the extension

### DIFF
--- a/apps/vscode-editor/src/theme.ts
+++ b/apps/vscode-editor/src/theme.ts
@@ -31,15 +31,15 @@ export function editorThemeFromVSCode(fontFamily?: string, fontSizePx?: number) 
   const theme = defaultTheme();
 
   // get vscode theme colors
-  const colors: Record<string,string> = {};
+  const colors: Record<string, string> = {};
   Object.values(document.getElementsByTagName('html')[0].style)
     .forEach((rv) => {
       colors[rv] = document
         .getElementsByTagName('html')[0]
-        .style.getPropertyValue(rv)
+        .style.getPropertyValue(rv);
     }
-  );
-  
+    );
+
   const bodyCls = document.body.classList;
   const hcLight = bodyCls.contains('vscode-high-contrast-light');
   const hcDark = bodyCls.contains('vscode-high-contrast') && !hcLight;
@@ -48,10 +48,10 @@ export function editorThemeFromVSCode(fontFamily?: string, fontSizePx?: number) 
   theme.solarizedMode = isSolarizedThemeActive();
   theme.cursorColor = colors["--vscode-editorCursor-foreground"];
   theme.selectionColor = colors["--vscode-editor-selectionBackground"];
-  theme.selectionForegroundColor = colors["--vscode-editor-selectionForeground"]
+  theme.selectionForegroundColor = colors["--vscode-editor-selectionForeground"];
   theme.nodeSelectionColor = colors["--vscode-notebook-focusedCellBorder"];
   theme.backgroundColor = colors["--vscode-editor-background"];
-  theme.metadataBackgroundColor =  theme.backgroundColor;
+  theme.metadataBackgroundColor = theme.backgroundColor;
   theme.chunkBackgroundColor = colors["--vscode-notebook-cellEditorBackground"];
   theme.spanBackgroundColor = theme.chunkBackgroundColor;
   theme.divBackgroundColor = theme.chunkBackgroundColor;
@@ -62,12 +62,12 @@ export function editorThemeFromVSCode(fontFamily?: string, fontSizePx?: number) 
   theme.linkTextColor = colors["--vscode-textLink-foreground"];
   theme.placeholderTextColor = colors["--vscode-editorGhostText-foreground"];
   theme.invisibleTextColor = colors["--vscode-editorWhitespace-foreground"];
-  theme.markupTextColor = theme.darkMode 
-    ? colors["--vscode-charts-orange"] 
+  theme.markupTextColor = theme.darkMode
+    ? colors["--vscode-charts-orange"]
     : colors["--vscode-editorInfo-foreground"];
   theme.findTextBackgroundColor = colors["--vscode-editor-foldBackground"];
   theme.findTextBorderColor = "transparent";
-  theme.borderBackgroundColor = theme.darkMode 
+  theme.borderBackgroundColor = theme.darkMode
     ? colors["--vscode-titleBar-activeBackground"]
     : colors["--vscode-titleBar-inactiveBackground"];
   theme.gutterBackgroundColor = theme.borderBackgroundColor;
@@ -78,9 +78,9 @@ export function editorThemeFromVSCode(fontFamily?: string, fontSizePx?: number) 
   theme.surfaceWidgetTextColor = theme.gutterTextColor;
   theme.focusOutlineColor = colors["--vscode-focusBorder"];
   theme.paneBorderColor = theme.darkMode ? colors["--vscode-commandCenter-border"] : colors["--vscode-panel-border"];
-  theme.blockBorderColor = theme.darkMode 
-  ? theme.paneBorderColor
-  : colors["--vscode-notebook-cellBorderColor"];
+  theme.blockBorderColor = theme.darkMode
+    ? theme.paneBorderColor
+    : colors["--vscode-notebook-cellBorderColor"];
   theme.hrBackgroundColor = theme.highContrast ? colors["--vscode-list-deemphasizedForeground"] : theme.blockBorderColor;
   theme.fixedWidthFont = colors["--vscode-editor-font-family"];
   theme.proportionalFont = fontFamily || defaultPrefs().fontFamily;
@@ -91,7 +91,7 @@ export function editorThemeFromVSCode(fontFamily?: string, fontSizePx?: number) 
     const match = editorFontSize.match(/(\d+)px/);
     fontSizePx = match ? parseInt(match[1]) : 12;
   }
-  const fontSizePt = Math.round(fontSizePx / 1.333) ;
+  const fontSizePt = Math.round(fontSizePx / 1.333);
   theme.fixedWidthFontSizePt = fontSizePt;
   theme.proportionalFontSizePt = fontSizePt + 1;
   theme.suggestWidgetBackgroundColor = colors["--vscode-editorSuggestWidget-background"];

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -25,6 +25,58 @@ import { textFormattingCommands } from "./providers/text-format";
 import { activateCodeFormatting } from "./providers/format";
 import { activateContextKeySetter } from "./providers/context-keys";
 import { ExtensionHost } from "./host";
+import path, { dirname } from "node:path";
+import { readFileSync } from "node:fs";
+
+export function getActiveThemeName(): string | undefined {
+  return vscode.workspace.getConfiguration("workbench").get("colorTheme");
+}
+// reference: https://github.com/microsoft/vscode/issues/32813#issuecomment-524174937
+// reference: https://github.com/textX/textX-LS/blob/master/client/src/utils.ts
+export function getTokenColorsForTheme(themeName: string | undefined): Map<any, any> {
+  const tokenColors = new Map();
+  if (!themeName) return tokenColors;
+  let currentThemePath;
+  for (const extension of vscode.extensions.all) {
+    const themes = extension.packageJSON.contributes && extension.packageJSON.contributes.themes;
+    const currentTheme = themes && themes.find((theme: any) => theme.id === themeName);
+    if (currentTheme) {
+      currentThemePath = path.join(extension.extensionPath, currentTheme.path);
+      break;
+    }
+  }
+  const themePaths = [];
+  if (currentThemePath) { themePaths.push(currentThemePath); }
+  while (themePaths.length > 0) {
+    const themePath = themePaths.pop();
+    if (themePath === undefined) return tokenColors;
+    const theme = loadJSON(themePath);
+    if (theme) {
+      if (theme.include) {
+        themePaths.push(path.join(dirname(themePath), theme.include));
+      }
+      if (theme.tokenColors) {
+        theme.tokenColors.forEach((rule: any) => {
+          if (typeof rule.scope === "string" && !tokenColors.has(rule.scope)) {
+            tokenColors.set(rule.scope, rule.settings);
+          } else if (rule.scope instanceof Array) {
+            rule.scope.forEach((scope: any) => {
+              if (!tokenColors.has(rule.scope)) {
+                tokenColors.set(scope, rule.settings);
+              }
+            });
+          }
+        });
+      }
+    }
+  }
+  return tokenColors;
+}
+export function loadJSON(path: string): any {
+  try {
+    return JSON.parse(readFileSync(path).toString());
+  } catch { }
+}
 
 export function activateCommon(
   context: vscode.ExtensionContext,
@@ -32,6 +84,11 @@ export function activateCommon(
   engine: MarkdownEngine,
   commands?: Command[]
 ) {
+  console.log(
+    'HELLO getCurrentTheme',
+    getActiveThemeName(),
+    [...getTokenColorsForTheme(getActiveThemeName()).entries()].map(([k, v]) => [k, Object.entries(v)])
+  );
   // option enter handler
   activateOptionEnterProvider(context, engine);
 


### PR DESCRIPTION
## The problem

As reported in #525, the visual editor does not use code highlighting colors from the user's vscode color theme. 

The extension does get some colors from the theme, but it does not get any code highlighting related colors. I believe the extension includes its own code highlighting color themes for each of the default vscode themes. If the user is using a built-in vscode theme (e.g. Monokai, Solarized, etc.) then the extension is able to guess that and select a matching theme definition from its own list. However, if the user is not using a built-in vscode theme, the extension somehow picks one of the built-in themes to use as the code highlighting them.

You can see this maybe most glaringly with a monochrome theme from the extension store:

| Source Editor with Monochromatic theme   | Visual Editor with same Monochromatic theme |
| -------- | ------- |
| <img width="583" height="429" alt="Screenshot 2025-07-25 at 11 24 15 AM" src="https://github.com/user-attachments/assets/57b21ed8-7fa1-4a76-b7c7-60c66a1690e8" /> | <img width="731" height="397" alt="Screenshot 2025-07-25 at 11 23 32 AM" src="https://github.com/user-attachments/assets/913a76c2-84c9-4ba0-9bec-5f486715ea2e" />  |

---

## Can we get the user's theme colors?

Yes, to some extent at least. This PR so far gives a prototype of getting and logging code highlighting theme data from the user's vscode theme. Here's an example of what we can get:

<details><summary>Here's an example of the data we get</summary>

```
'[["comment",[["foreground","#6a737d"]]],["punctuation.definition.comment",[["foreground","#6a737d"]]],["string.comment",[["foreground","#6a737d"]]],["constant",[["foreground","#005cc5"]]],["entity.name.constant",[["foreground","#005cc5"]]],["variable.other.constant",[["foreground","#005cc5"]]],["variable.language",[["foreground","#005cc5"]]],["keyword.operator.symbole",[["foreground","#000000"]]],["keyword.other.mark",[["foreground","#000000"]]],["entity",[["foreground","#6f42c1"]]],["entity.name",[["foreground","#6f42c1"]]],["variable.parameter.function",[["foreground","#000000"]]],["entity.name.tag",[["foreground","#22863a"]]],["keyword",[["foreground","#d73a49"]]],["storage",[["foreground","#d73a49"]]],["storage.type",[["foreground","#d73a49"]]],["storage.modifier.package",[["foreground","#000000"]]],["storage.modifier.import",[["foreground","#000000"]]],["storage.type.java",[["foreground","#000000"]]],["string",[["foreground","#032f62"]]],["punctuation.definition.string",[["foreground","#032f62"]]],["string punctuation.section.embedded source",[["foreground","#032f62"]]],["string.unquoted.import.ada",[]],["support",[["foreground","#005cc5"]]],["meta.property-name",[["foreground","#005cc5"]]],["variable",[["foreground","#e36209"]]],["variable.other",[["foreground","#000000"]]],["invalid.broken",[["fontStyle","bold italic underline"],["foreground","#b31d28"]]],["invalid.deprecated",[["fontStyle","bold italic underline"],["foreground","#b31d28"]]],["invalid.illegal",[["fontStyle","italic underline"],["foreground","#b31d28"]]],["carriage-return",[["fontStyle","italic underline"],["foreground","#d73a49"]]],["invalid.unimplemented",[["fontStyle","bold italic underline"],["foreground","#b31d28"]]],["message.error",[["foreground","#b31d28"]]],["string source",[["foreground","#000000"]]],["string variable",[["foreground","#005cc5"]]],["source.regexp",[["foreground","#032f62"]]],["string.regexp",[["foreground","#032f62"]]],["string.regexp.character-class",[["foreground","#032f62"]]],["string.regexp constant.character.escape",[["fontStyle","bold"],["foreground","#22863a"]]],["string.regexp source.ruby.embedded",[["foreground","#032f62"]]],["string.regexp string.regexp.arbitrary-repitition",[["foreground","#032f62"]]],["support.constant",[["foreground","#005cc5"]]],["support.variable",[["foreground","#005cc5"]]],["meta.module-reference",[["foreground","#005cc5"]]],["markup.list",[["foreground","#735c0f"]]],["markup.heading",[["fontStyle","bold"],["foreground","#005cc5"]]],["markup.heading entity.name",[["fontStyle","bold"],["foreground","#005cc5"]]],["markup.quote",[["foreground","#22863a"]]],["markup.italic",[["fontStyle","italic"],["foreground","#000000"]]],["markup.bold",[["fontStyle","bold"],["foreground","#000000"]]],["markup.raw",[["foreground","#005cc5"]]],["markup.deleted",[["foreground","#b31d28"]]],["meta.diff.header.from-file",[["foreground","#b31d28"]]],["punctuation.definition.deleted",[["foreground","#b31d28"]]],["markup.inserted",[["foreground","#22863a"]]],["meta.diff.header.to-file",[["foreground","#22863a"]]],["punctuation.definition.inserted",[["foreground","#22863a"]]],["markup.changed",[["foreground","#e36209"]]],["punctuation.definition.changed",[["foreground","#e36209"]]],["markup.ignored",[["foreground","#005cc5"]]],["markup.untracked",[["foreground","#005cc5"]]],["meta.diff.range",[["foreground","#6f42c1"],["fontStyle","bold"]]],["meta.diff.header",[["foreground","#005cc5"]]],["meta.separator",[["fontStyle","bold"],["foreground","#005cc5"]]],["meta.output",[["foreground","#005cc5"]]],["brackethighlighter.tag",[["foreground","#586069"]]],["brackethighlighter.curly",[["foreground","#586069"]]],["brackethighlighter.round",[["foreground","#586069"]]],["brackethighlighter.square",[["foreground","#586069"]]],["brackethighlighter.angle",[["foreground","#586069"]]],["brackethighlighter.quote",[["foreground","#586069"]]],["brackethighlighter.unmatched",[["foreground","#b31d28"]]],["sublimelinter.mark.error",[["foreground","#b31d28"]]],["sublimelinter.mark.warning",[["foreground","#e36209"]]],["sublimelinter.gutter-mark",[["foreground","#959da5"]]],["constant.other.reference.link",[["foreground","#032f62"],["fontStyle","underline"]]],["string.other.link",[["foreground","#032f62"],["fontStyle","underline"]]],["meta.function-call support.function",[["foreground","#005cc5"]]],["meta.function-call entity.name.function",[["foreground","#005cc5"]]],["keyword.operator",[["foreground","#000000"]]]]'
```

</details>