### PR TITLE
Add some roundtripping vscode tests

### DIFF
--- a/apps/vscode/src/test/examples/hello.qmd
+++ b/apps/vscode/src/test/examples/hello.qmd
@@ -10,3 +10,5 @@ format: html
 ```
 
 *YO!*
+
+note the lack of newline at the end of this file.

--- a/apps/vscode/src/test/quartoDoc.test.ts
+++ b/apps/vscode/src/test/quartoDoc.test.ts
@@ -1,50 +1,31 @@
 import * as vscode from "vscode";
 import * as assert from "assert";
-import { exampleWorkspacePath, exampleWorkspaceOutPath, copyFile, wait } from "./test-utils";
+import { WORKSPACE_PATH, examplesOutUri, wait } from "./test-utils";
 import { isQuartoDoc } from "../core/doc";
 import { extension } from "./extension";
 
 const APPROX_TIME_TO_OPEN_VISUAL_EDITOR = 1700;
 
 suite("Quarto basics", function () {
-  // Before we run any tests, we should copy any files that get edited in the tests to file under `exampleWorkspaceOutPath`
+  // Before running tests, copy `./examples` to a new folder `./examples-out`.
+  // We copy to examples-out because the tests modify the files.
   suiteSetup(async function () {
-    const didCopyFile = await copyFile(exampleWorkspacePath('hello.qmd'), exampleWorkspaceOutPath('hello.qmd'));
-    assert.ok(didCopyFile);
+    await vscode.workspace.fs.delete(examplesOutUri(), { recursive: true });
+    await vscode.workspace.fs.copy(vscode.Uri.file(WORKSPACE_PATH), examplesOutUri());
   });
-
   test("Can open a Quarto document", async function () {
-    const doc = await vscode.workspace.openTextDocument(exampleWorkspaceOutPath("hello.qmd"));
+    const doc = await vscode.workspace.openTextDocument(examplesOutUri("hello.qmd"));
     const editor = await vscode.window.showTextDocument(doc);
 
     assert.strictEqual(editor?.document.languageId, "quarto");
     assert.strictEqual(isQuartoDoc(editor?.document), true);
   });
-
-  // Note: the following tests may be flaky. They rely on waiting estimated amounts of time for commands to complete.
-  test("Can edit in visual mode", async function () {
-    const doc = await vscode.workspace.openTextDocument(exampleWorkspaceOutPath("hello.qmd"));
-    const editor = await vscode.window.showTextDocument(doc);
-
-    await extension().activate();
-
-    // manually confirm visual mode so dialogue pop-up doesn't show because dialogues cause test errors
-    // and switch to visual editor
-    await vscode.commands.executeCommand("quarto.test_setkVisualModeConfirmedTrue");
-    await wait(300); // It seems necessary to wait around 300ms for this command to be done.
-    await vscode.commands.executeCommand("quarto.editInVisualMode");
-    await wait(APPROX_TIME_TO_OPEN_VISUAL_EDITOR);
-
-    assert.ok(await vscode.commands.executeCommand("quarto.test_isInVisualEditor"));
-  });
-  // Note: this test runs after the previous test, so `hello.qmd` has already been touched by the previous
+  // Note: this test runs after the previous test, so `hello.qmd` can already be touched by the previous
   //       test. That's okay for this test, but could cause issues if you expect a qmd to look how it
   //       does in `/examples`.
   test("Roundtrip doesn't change hello.qmd", async function () {
-    const doc = await vscode.workspace.openTextDocument(exampleWorkspaceOutPath("hello.qmd"));
+    const doc = await vscode.workspace.openTextDocument(examplesOutUri("hello.qmd"));
     const editor = await vscode.window.showTextDocument(doc);
-
-    await extension().activate();
 
     const docTextBefore = doc.getText();
 
@@ -57,6 +38,6 @@ suite("Quarto basics", function () {
     await wait(300);
 
     const docTextAfter = doc.getText();
-    assert.ok(docTextBefore === docTextAfter, docTextAfter);
+    assert.equal(docTextBefore, docTextAfter);
   });
 });

--- a/apps/vscode/src/test/test-utils.ts
+++ b/apps/vscode/src/test/test-utils.ts
@@ -13,36 +13,12 @@ export const EXTENSION_ROOT_DIR =
 
 export const TEST_PATH = path.join(EXTENSION_ROOT_DIR, "src", "test");
 export const WORKSPACE_PATH = path.join(TEST_PATH, "examples");
+export const WORKSPACE_OUT_PATH = path.join(TEST_PATH, "examples-out");
 
-export function exampleWorkspacePath(file: string): string {
-  return path.join(WORKSPACE_PATH, file);
-}
-export function exampleWorkspaceOutPath(file: string): string {
-  return path.join(WORKSPACE_PATH, 'examples-out', file);
+export function examplesOutUri(fileName: string = ''): vscode.Uri {
+  return vscode.Uri.file(path.join(WORKSPACE_OUT_PATH, fileName));
 }
 
 export function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-export async function copyFile(
-  sourcePath: string,
-  destPath: string,
-): Promise<boolean> {
-  try {
-    const wsedit = new vscode.WorkspaceEdit();
-    const data = await vscode.workspace.fs.readFile(
-      vscode.Uri.file(sourcePath)
-    );
-    const destFileUri = vscode.Uri.file(destPath);
-    wsedit.createFile(destFileUri, { ignoreIfExists: true });
-
-    await vscode.workspace.fs.writeFile(destFileUri, data);
-
-    let isDone = await vscode.workspace.applyEdit(wsedit);
-    if (isDone) return true;
-    else return false;
-  } catch (err) {
-    return false;
-  }
 }


### PR DESCRIPTION
We want to add Quarto extension tests for roundtripping so that, at the very least, we can have descriptions of various ways roundtripping can affect `.qmd`s.