### PR TITLE
Debug: log to show difference in `vscode.executeCompletionItemProvider` in vscode vs Positron

### DIFF
--- a/apps/vscode/src/providers/editor/codeview.ts
+++ b/apps/vscode/src/providers/editor/codeview.ts
@@ -105,12 +105,12 @@ export function vscodeCodeViewServer(_engine: MarkdownEngine, document: TextDocu
       // if this is Positron, no visual editor completions
       // TODO: fix LSP issues for visual editor in Positron:
       // https://github.com/posit-dev/positron/issues/1805
-      if (hasHooks()) {
-        return {
-          items: [],
-          isIncomplete: false
-        };
-      }
+      // if (hasHooks()) {
+      //   return {
+      //     items: [],
+      //     isIncomplete: false
+      //   };
+      // }
 
       // otherwise delegate to vscode completion system
       const vdoc = virtualDocForCode(context.code, language);

--- a/apps/vscode/src/vdoc/vdoc-completion.ts
+++ b/apps/vscode/src/vdoc/vdoc-completion.ts
@@ -25,6 +25,7 @@ export async function vdocCompletions(
   parentUri: Uri
 ) {
   const completions = await withVirtualDocUri(vdoc, parentUri, "completion", async (uri: Uri) => {
+    console.log('vdocCompletions vdoc uri, adjustedPosition, trigger', uri, adjustedPosition(language, position), trigger)
     return await commands.executeCommand<CompletionList>(
       "vscode.executeCompletionItemProvider",
       uri,
@@ -32,6 +33,7 @@ export async function vdocCompletions(
       trigger
     );
   });
+  console.log('completions!!!', completions)
   return completions.items.map((completion: CompletionItem) => {
     if (language.inject && completion.range) {
       if (completion.range instanceof Range) {
@@ -49,5 +51,4 @@ export async function vdocCompletions(
     }
     return completion;
   });
-
 }

--- a/packages/editor-codemirror/src/behaviors/completion.ts
+++ b/packages/editor-codemirror/src/behaviors/completion.ts
@@ -114,6 +114,8 @@ async function getCompletions(
     return null;
   }
 
+  console.log('getCompletions', completions, [...completions.items])
+
   // order completions
   const haveOrder = !!completions.items?.[0].sortText;
   if (haveOrder) {


### PR DESCRIPTION
Please see the comments on the modified code in this PR.