### PR TITLE
refactor prosemirror conversion for understandability

### DIFF
--- a/packages/editor/src/nodes/list/list-checked.ts
+++ b/packages/editor/src/nodes/list/list-checked.ts
@@ -20,7 +20,7 @@ import { findParentNodeOfType, NodeWithPos, setTextSelection } from 'prosemirror
 import { InputRule, wrappingInputRule } from 'prosemirror-inputrules';
 
 import { ProsemirrorCommand, EditorCommandId } from '../../api/command';
-import { PandocToken, mapTokens } from '../../api/pandoc';
+import { PandocToken, mapTokensRecursive } from '../../api/pandoc';
 
 // custom NodeView that accomodates display / interaction with item check boxes
 export class CheckedListItemNodeView implements NodeView {
@@ -28,7 +28,7 @@ export class CheckedListItemNodeView implements NodeView {
   public readonly contentDOM: HTMLElement;
 
   constructor(node: ProsemirrorNode, view: EditorView, getPos: () => number) {
-    
+
     // create root li element
     this.dom = window.document.createElement('li');
     if (node.attrs.tight) {
@@ -167,7 +167,7 @@ export function checkedListItemInputRule() {
 }
 
 export interface InputRuleWithHandler extends InputRule {
-  handler: (state: EditorState, match: RegExpMatchArray, start: number, end: number) => Transaction
+  handler: (state: EditorState, match: RegExpMatchArray, start: number, end: number) => Transaction;
 }
 
 // allow users to begin a new checked list by typing [x] or [ ] at the beginning of a line
@@ -212,13 +212,13 @@ export function fragmentWithCheck(schema: Schema, fragment: Fragment, checked: b
 const kCheckedChar = '☒';
 const kUncheckedChar = '☐';
 
-export function tokensWithChecked(tokens: PandocToken[]): { checked: null | boolean; tokens: PandocToken[] } {
+export function tokensWithChecked(tokens: PandocToken[]): { checked: null | boolean; tokens: PandocToken[]; } {
   // will set this flag based on inspecting the first Str token
   let checked: null | boolean | undefined;
   let lastWasChecked = false;
 
   // map tokens
-  const mappedTokens = mapTokens(tokens, tok => {
+  const mappedTokens = mapTokensRecursive(tokens, tok => {
     // if the last token was checked then strip the next space
     if (tok.t === 'Space' && lastWasChecked) {
       lastWasChecked = false;

--- a/packages/editor/src/pandoc/pandoc_to_prosemirror.ts
+++ b/packages/editor/src/pandoc/pandoc_to_prosemirror.ts
@@ -423,9 +423,11 @@ class ParserState {
   }
 
   private maybeMerge(a: ProsemirrorNode, b: ProsemirrorNode): ProsemirrorNode | undefined {
-    return a?.isText && b?.isText && Mark.sameSet(a.marks, b.marks) ?
-      this.schema.text((a.text as string) + b.text, a.marks) :
-      undefined;
+    if (a?.isText && b?.isText && Mark.sameSet(a.marks, b.marks)) {
+      return this.schema.text(a.text! + b.text, a.marks);
+    } else {
+      return undefined;
+    }
   }
 }
 


### PR DESCRIPTION
## Changes

- Apply formatter to changed files (mostly normalize whitespace, semicolons)
- Big refactor of `mapTokens` (renamed to `mapTokensRecursive`)
  - Move nested functions out
  - Clarify `isToken` logic by removing redundant logic
  - This function has somewhat brain-bending recursive functionality (I was confused and I also saw it being misused in `resolvePandocBlockCapsuleText`, resulting in redundant logic). It has two interrelated recursive parts. A "recursive array data mapping" part and a "recursive function output content mapping" part. Because of the recursive nature of this function, I feel justified in going _full functional programmer_ on its refactor: I refactored into two separate functions that return functions: `mapRecursiveArray` factors out the "recursive array data mapping" part, and `mapTokenAndContentTokensRecursively` factors out the "recursive function output content mapping" part. It is still a difficult function to understand, but I've removed some redundancy and made how its parts depend on eachother more direct and explicit.
  - Add docs
- After refactoring `mapTokensRecursive` I understood it better and was able to understand and significantly simplify `resolvePandocBlockCapsuleText`
- Change `writeToken` to prefer Array.find over iterating through the array until the element is found.
- Refactor `createHandlers`
  - Pulls out the non-looping part into `createHandler` which is nice because it can now early return instead of modifying a variable.
 
## TODO

- [x] add tests to increase confidence that this refactor does not change roundtripping behaviour. DONE in #790


_Could we add tests to see if the prosemirror doc was instantiated properly as well?_