### PR TITLE
fix "capsule leak" when no empty line between text and code block

### DIFF
--- a/apps/vscode/src/test/examples/capsule-leak.qmd
+++ b/apps/vscode/src/test/examples/capsule-leak.qmd
@@ -1,0 +1,5 @@
+The lack of newline between this text and the code block previously caused a capsule leak. See https://github.com/quarto-dev/quarto/pull/780
+```{{python}}
+1+2
+```
+lets also snapshot what happens to this text after the code block

--- a/apps/vscode/src/test/examples/generated_snapshots/roundtripped-capsule-leak.qmd
+++ b/apps/vscode/src/test/examples/generated_snapshots/roundtripped-capsule-leak.qmd
@@ -1,0 +1,7 @@
+The lack of newline between this text and the code block previously caused a capsule leak. See https://github.com/quarto-dev/quarto/pull/780
+
+```{{python}}
+1+2
+```
+
+lets also snapshot what happens to this text after the code block

--- a/apps/vscode/src/test/examples/roundtrip-changes.qmd
+++ b/apps/vscode/src/test/examples/roundtrip-changes.qmd
@@ -4,13 +4,6 @@ hi
 ```
 ``````
 
-kBlockCapsuleSentinel uuid sentinel leak during SE→VE
-``````{{python}}
-```
-dog
-```
-``````
-
 `````
 ```{python}
 a = 3

--- a/apps/vscode/src/test/quartoDoc.test.ts
+++ b/apps/vscode/src/test/quartoDoc.test.ts
@@ -57,4 +57,11 @@ suite("Quarto basics", function () {
 
     assert.equal(after, await readOrCreateSnapshot("roundtripped-invalid.qmd", after));
   });
+  test("Roundtripped capsule-leak.qmd matches snapshot", async function () {
+    const { doc } = await openAndShowTextDocument("capsule-leak.qmd");
+
+    const { after } = await roundtrip(doc);
+
+    assert.equal(after, await readOrCreateSnapshot("roundtripped-capsule-leak.qmd", after));
+  });
 });

--- a/packages/editor/src/api/pandoc_capsule.ts
+++ b/packages/editor/src/api/pandoc_capsule.ts
@@ -259,6 +259,28 @@ export function blockCapsuleParagraphTokenHandler(type: string) {
   };
 }
 
+export function blockCapsuleStrTokenHandler(type: string) {
+  const tokenRegex = encodedBlockCapsuleRegex('^', '$');
+  return (tok: PandocToken) => {
+    if (tok.t === PandocTokenType.Str) {
+      const text = tok.c as string;
+      const match = text.match(tokenRegex);
+      if (match) {
+        const capsuleRecord = parsePandocBlockCapsule(match[0]);
+        if (capsuleRecord.type === type) {
+          return match[0];
+        }
+      }
+    }
+    return null;
+  };
+}
+
+export const blockCapsuleHandlerOr = (
+  handler1: (tok: PandocToken) => string | null,
+  handler2: (tok: PandocToken) => string | null
+) => (tok: PandocToken) => handler1(tok) ?? handler2(tok);
+
 // create a regex that can be used to match a block capsule
 export function encodedBlockCapsuleRegex(prefix?: string, suffix?: string, flags?: string) {
   return new RegExp(


### PR DESCRIPTION
## Problem
### Example
The content of a .qmd document that caused a capsule leak:
`````
hello
```{{python}}
1+2
```
`````
After opening this document in the visual editor:
```
hello 31b8e172-b470-440e-83d8-e6b185028602:dAB5AHAAZQA6AE8AUQBCAGoAQQBHAEkAQQBOAHcAQQA1AEEARwBVAEEATgBnAEIAagBBAEMAMABBAE8AQQBBADQAQQBEAGcAQQBaAEEAQQB0AEEARABRAEEAWQBRAEEAdwBBAEcAVQBBAEwAUQBBADUAQQBHAE0AQQBPAFEAQgBpAEEAQwAwAEEAWgBnAEIAbQBBAEQAWQBBAE4AdwBCAGoAQQBHAFEAQQBOAEEAQQB3AEEARABRAEEAWgBRAEEAMgBBAEQAQQBBAAoAcABvAHMAaQB0AGkAbwBuADoATgBnAEEAPQAKAHAAcgBlAGYAaQB4ADoACgBzAG8AdQByAGMAZQA6AFkAQQBCAGcAQQBHAEEAQQBlAHcAQgA3AEEASABBAEEAZQBRAEIAMABBAEcAZwBBAGIAdwBCAHUAQQBIADAAQQBmAFEAQQBLAEEARABFAEEASwB3AEEAeQBBAEEAbwBBAFkAQQBCAGcAQQBHAEEAQQAKAHMAdQBmAGYAaQB4ADoA:31b8e172-b470-440e-83d8-e6b185028602
```
We see an entire capsule instead of the code block! Note that this shows an example of a `<CAPSULE>`.

### Description
In the process of switching **to** the visual editor there are three relevant steps:
1. modifying the .qmd string by turning code blocks into capsules
2. passing the modified string to pandoc to get an AST
3. converting the AST to a prosemirror document

**What are capsules?** Capsules are base64 encoded strings with a uuid prefix that replace parts of a document so that they are not parsed based on their structure by pandoc (we are smuggling certain parts of the document through the pandoc parse). After pandoc parses the document into an AST we find the capsules in the AST and decode them into their original content. The user should never see capsules.

**Why does the bug happen?** In the example, there is not an empty line between the text "hello" and the code block. In step 1, the code block is turned into a capsule, resulting in a string of this form:
```
hello
<CAPSULE>
```
Now in step 2, this string is passed to pandoc, which, since there is no empty line between "hello" and the capsule, parses as a single paragraph like 
```
[ Para
    [ Str "hello"
    , SoftBreak
    , Str <CAPSULE>
    ]
]
```
Now in step 3, unfortunately when looking for code block capsules in the AST, we were looking (`blockCapsuleParagraphTokenHandler(kEscapedRmdChunkBlockCapsuleType)`) only for paragraphs with a single content  that held a capsule string. As a result this capsule was not detected and was treated as a normal string in a paragraph, being written directly into the prosemirror document.

## Fix

We now understand that code block capsules can end up as a `Str` in paragraphs with multiple content, so we now look for those cases with this new code:
```typescript
handleToken:
  blockCapsuleHandlerOr(
    blockCapsuleParagraphTokenHandler(kEscapedRmdChunkBlockCapsuleType),
    blockCapsuleStrTokenHandler(kEscapedRmdChunkBlockCapsuleType)
  ),
```
Which detects a block capsule in the case of paragraphs with a single Str content (as was previously checked), or in the case of any Str that looks like a code block capsule. Note that this detection logic is a bit redundant, but I think it may be slightly more "surgical" of a change because the old detection method is still used when it can be (we change as little behaviour as we can).

As a result of this new detection, we had to modify how code blocks are written into the prosemirror document. When a code block capsule is detected the prosemirror writer may now be in a state where it is writing into a paragraph block because code block capsules can now be inside paragraphs with other content. When this it is the case that a code block capsule is in a paragraph (`writer.isNodeOpen(schema.nodes.paragraph)`) we now close the paragraph, write the code block, then open a paragraph.

## Method

- @cscheid and I attempted another fix where we prepended and appended newlines before code block capsules. Unfortunately, in the case of code blocks in code blocks, this was seen to introduce additional newlines into the document on every roundtrip.

- I did a bunch of refactors/clean-ups/logs in this area to get a handle on what is happening in the visual editor when converting to the visual editor. The refactors and clean-ups are captured in this PR https://github.com/quarto-dev/quarto/pull/779. Here is a picture of some logs that shows the start of the actions that the prosemirror writer does during conversion (The prosemirror writer is invoked as the final step in the conversion process):
<img width="1600" height="1466" alt="image" src="https://github.com/user-attachments/assets/303e5761-7de5-4a85-a538-7c262dc5e68e" />
