### PR TITLE
Fix/vscode format cell continued

### DIFF
--- a/apps/vscode/src/providers/format.ts
+++ b/apps/vscode/src/providers/format.ts
@@ -209,8 +209,7 @@ async function formatActiveCell(editor: TextEditor, engine: MarkdownEngine) {
 
 async function formatBlock(doc: TextDocument, block: TokenMath | TokenCodeBlock, language: EmbeddedLanguage) {
   // Create virtual document containing the block
-  const blockLines = lines(codeForExecutableLanguageBlock(block));
-  blockLines.push("");
+  const blockLines = lines(codeForExecutableLanguageBlock(block, false));
   const vdoc = virtualDocForCode(blockLines, language);
 
   const edits = await executeFormatDocumentProvider(

--- a/apps/vscode/src/providers/format.ts
+++ b/apps/vscode/src/providers/format.ts
@@ -233,8 +233,17 @@ async function formatBlock(doc: TextDocument, block: TokenMath | TokenCodeBlock,
           new Position(edit.range.end.line + block.range.start.line + 1, edit.range.end.character)
         );
         return new TextEdit(range, edit.newText);
-      })
-      .filter(edit => blockRange.contains(edit.range));
+      });
+
+    // Bail if any edit is out of range. We used to filter these edits out but
+    // this could bork the cell.
+    if (edits.some(edit => !blockRange.contains(edit.range))) {
+      window.showInformationMessage(
+        "Formatting edits were out of range and could not be applied to the code cell."
+      );
+      return [];
+    }
+
     return adjustedEdits;
   }
 }

--- a/apps/vscode/src/providers/format.ts
+++ b/apps/vscode/src/providers/format.ts
@@ -138,9 +138,13 @@ class FormatCellCommand implements Command {
       const edits = await formatActiveCell(editor, this.engine_);
       if (edits) {
         editor.edit((editBuilder) => {
-          edits.forEach((edit) => {
-            editBuilder.replace(edit.range, edit.newText);
-          });
+          // Sort edits by descending start position to avoid range shifting issues
+          edits
+            .slice()
+            .sort((a, b) => b.range.start.compareTo(a.range.start))
+            .forEach((edit) => {
+              editBuilder.replace(edit.range, edit.newText);
+            });
         });
       } else {
         window.showInformationMessage(
@@ -204,15 +208,21 @@ async function formatActiveCell(editor: TextEditor, engine: MarkdownEngine) {
 }
 
 async function formatBlock(doc: TextDocument, block: TokenMath | TokenCodeBlock, language: EmbeddedLanguage) {
+  // Create virtual document containing the block
   const blockLines = lines(codeForExecutableLanguageBlock(block));
   blockLines.push("");
   const vdoc = virtualDocForCode(blockLines, language);
+
   const edits = await executeFormatDocumentProvider(
     vdoc,
     doc,
     formattingOptions(doc.uri, vdoc.language)
   );
+
   if (edits) {
+    // Because we format with the block code copied in an empty virtual
+    // document, we need to adjust the ranges to match the edits to the block
+    // cell in the original file.
     const blockRange = new Range(
       new Position(block.range.start.line, block.range.start.character),
       new Position(block.range.end.line, block.range.end.character)

--- a/apps/vscode/src/providers/format.ts
+++ b/apps/vscode/src/providers/format.ts
@@ -233,16 +233,7 @@ async function formatBlock(doc: TextDocument, block: TokenMath | TokenCodeBlock,
           new Position(edit.range.end.line + block.range.start.line + 1, edit.range.end.character)
         );
         return new TextEdit(range, edit.newText);
-      });
-
-    // Bail if any edit is out of range. We used to filter these edits out but
-    // this could bork the cell.
-    if (edits.some(edit => !blockRange.contains(edit.range))) {
-      window.showInformationMessage(
-        "Formatting edits were out of range and could not be applied to the code cell."
-      );
-      return [];
-    }
+      }).filter(edit => blockRange.contains(edit.range));
 
     return adjustedEdits;
   }

--- a/apps/vscode/src/test/examples/cell-format.qmd
+++ b/apps/vscode/src/test/examples/cell-format.qmd
@@ -1,0 +1,11 @@
+See https://github.com/quarto-dev/quarto/issues/745 "Reformating R cell in VSCODE with air does not correctly close chunk."
+
+```{r}
+list(foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar)
+```
+
+```{r}
+
+list(foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar, foobar)
+
+```

--- a/apps/vscode/src/test/quartoDoc.test.ts
+++ b/apps/vscode/src/test/quartoDoc.test.ts
@@ -30,16 +30,42 @@ suite("Quarto basics", function () {
     assert.equal(before, after);
   });
 
-  roundtripSnapshotTest('valid-basics.qmd');
+  // roundtripSnapshotTest('valid-basics.qmd');
 
-  roundtripSnapshotTest('valid-basics-2.qmd');
+  // roundtripSnapshotTest('valid-basics-2.qmd');
 
-  roundtripSnapshotTest('valid-nesting.qmd');
+  // roundtripSnapshotTest('valid-nesting.qmd');
 
-  roundtripSnapshotTest('invalid.qmd');
+  // roundtripSnapshotTest('invalid.qmd');
 
-  roundtripSnapshotTest('capsule-leak.qmd');
+  // roundtripSnapshotTest('capsule-leak.qmd');
+
+  test("cell formamtmtamt", async function () {
+    const { doc } = await openAndShowTextDocument("cell-format.qmd");
+
+    //await vscode.commands.executeCommand("quarto.formatCell");
+    setCursorPosition(3, 1);
+    await vscode.commands.executeCommand("quarto.formatCell");
+    await wait(6300);
+    // const { before, after } = await roundtrip(doc);
+
+    // assert.equal(before, after);
+  });
+
+  suiteTeardown(() => {
+    vscode.window.showInformationMessage('All tests done!');
+  });
 });
+
+function setCursorPosition(line: number, character: number) {
+  const editor = vscode.window.activeTextEditor;
+  if (editor) {
+    const position = new vscode.Position(line, character);
+    const newSelection = new vscode.Selection(position, position);
+    editor.selection = newSelection;
+    editor.revealRange(newSelection, vscode.TextEditorRevealType.InCenter); // Optional: scroll to the new position
+  }
+}
 
 /**
  *

--- a/apps/vscode/src/test/quartoDoc.test.ts
+++ b/apps/vscode/src/test/quartoDoc.test.ts
@@ -22,13 +22,13 @@ suite("Quarto basics", function () {
   // Note: this test runs after the previous test, so `hello.qmd` can already be touched by the previous
   //       test. That's okay for this test, but could cause issues if you expect a qmd to look how it
   //       does in `/examples`.
-  test("Roundtrip doesn't change hello.qmd", async function () {
-    const { doc } = await openAndShowTextDocument("hello.qmd");
+  // test("Roundtrip doesn't change hello.qmd", async function () {
+  //   const { doc } = await openAndShowTextDocument("hello.qmd");
 
-    const { before, after } = await roundtrip(doc);
+  //   const { before, after } = await roundtrip(doc);
 
-    assert.equal(before, after);
-  });
+  //   assert.equal(before, after);
+  // });
 
   // roundtripSnapshotTest('valid-basics.qmd');
 
@@ -43,8 +43,25 @@ suite("Quarto basics", function () {
   test("cell formamtmtamt", async function () {
     const { doc } = await openAndShowTextDocument("cell-format.qmd");
 
-    //await vscode.commands.executeCommand("quarto.formatCell");
+    vscode.languages.registerDocumentFormattingEditProvider(
+      { scheme: 'file', language: 'r' },
+      {
+        provideDocumentFormattingEdits(document: vscode.TextDocument):
+          vscode.ProviderResult<vscode.TextEdit[]> {
+          const sourceText = document.getText();
+
+          const fileStart = new vscode.Position(0, 0);
+          const fileEnd = document.lineAt(document.lineCount - 1).range.end;
+
+          const formattedSourceText = sourceText + 'hello!'
+
+          return [new vscode.TextEdit(new vscode.Range(fileStart, fileEnd), formattedSourceText)];
+        }
+      }
+    )
+
     setCursorPosition(3, 1);
+    await wait(300);
     await vscode.commands.executeCommand("quarto.formatCell");
     await wait(6300);
     // const { before, after } = await roundtrip(doc);

--- a/packages/quarto-core/src/markdown/language.ts
+++ b/packages/quarto-core/src/markdown/language.ts
@@ -38,11 +38,14 @@ export function isExecutableLanguageBlock(token: Token) : token is TokenMath | T
   }
 }
 
-export function codeForExecutableLanguageBlock(token: TokenMath | TokenCodeBlock) {
+export function codeForExecutableLanguageBlock(
+  token: TokenMath | TokenCodeBlock,
+  appendNewline = true,
+) {
   if (isMath(token)) {
     return token.data.text;
   } else if (isCodeBlock(token)) {
-    return token.data + "\n";
+    return token.data + (appendNewline ? "\n" : "");
   } else {
     return "";
   }


### PR DESCRIPTION
edit: this PR is obsolete now, the changes have been moved over to #754 

---

A copy of @lionel-'s branch for PR #754 which addresses issue #745, but:
- rebased on main,
- with filtering of partial edits reverted,
- with an extension test that registers a custom formatting provider

Excuse me for copying the branch&PR to a new branch&PR, but I didn't feel comfortable force pushing to the original.

This is still a WIP. I don't currently know how to interpret the test results: When I ran this test with the main fix by @lionel- reverted (the one that adds a newline), the formatter does not seem to run at all... I don't understand why.

note: @juliasilge showed me [this PR that creates a minimal formatter](https://github.com/posit-dev/positron/pull/1686/files) for reference.