### PR TITLE
use `statementRangeProvider` in Positron to execute statements at cursor in VE

### DIFF
--- a/apps/vscode/src/providers/cell/commands.ts
+++ b/apps/vscode/src/providers/cell/commands.ts
@@ -49,6 +49,10 @@ import { ExtensionHost } from "../../host";
 import { hasHooks } from "../../host/hooks";
 import { isKnitrDocument } from "../../host/executors";
 import { commands } from "vscode";
+import { virtualDocForCode, withVirtualDocUri } from "../../vdoc/vdoc";
+import { embeddedLanguage } from "../../vdoc/languages";
+import { Uri } from "vscode";
+import { StatementRange } from "positron";
 
 export function cellCommands(host: ExtensionHost, engine: MarkdownEngine): Command[] {
   return [
@@ -345,15 +349,38 @@ class RunCurrentCommand extends RunCommand implements Command {
           await activateIfRequired(editor);
         }
       }
-
     } else {
-      // if the selection is empty take the whole line, otherwise take the selected text exactly
       let action: CodeViewSelectionAction | undefined;
-      if (selection.length <= 0) {
-        if (activeBlock) {
-          selection = lines(activeBlock.code)[context.selection.start.line];
+
+      // if the selection is empty and we are in Positron:
+      //   try to get the statement's range and use that as the selection
+      if (selection.length <= 0 && activeBlock && hasHooks()) {
+        const language = embeddedLanguage(activeBlock.language);
+        const vdoc = virtualDocForCode(lines(activeBlock.code), language!);
+        const parentUri = Uri.file(editor.document.fileName);
+        if (vdoc) {
+          const result = await withVirtualDocUri(vdoc, parentUri, "statementRange", async (uri) => {
+            return await commands.executeCommand<StatementRange>(
+              "vscode.executeStatementRangeProvider",
+              uri,
+              context.selection.start
+            );
+          });
+          const { range: { start, end } } = result
+          const slicedLines = lines(activeBlock.code).slice(start.line, end.line + 1)
+          slicedLines[0] = slicedLines[0].slice(start.character)
+          slicedLines[slicedLines.length - 1] = slicedLines[slicedLines.length - 1].slice(0, end.character)
+
+          selection = slicedLines.join('\n')
           action = "nextline";
         }
+      }
+
+      // if the selection is still empty:
+      //   take the whole line as the selection
+      if (selection.length <= 0 && activeBlock) {
+        selection = lines(activeBlock.code)[context.selection.start.line];
+        action = "nextline";
       }
 
       // run code


### PR DESCRIPTION
New in Positron: pressing ctrl+enter with your cursor in a multiline R statement executes the whole statement.

<img width="330" height="398" alt="Screenshot 2025-09-24 at 3 55 59 PM" src="https://github.com/user-attachments/assets/143b9158-681e-4c0e-8ccb-994a5cd28b67" />

Before it would only execute the current line.

Note: this fix relies on Positron's `vscode.executeStatementRangeProvider` command and does not work in VSCode. I was attempting to get this working in VSCode by creating a virtual doc for the code block, setting your cursor in the virtual doc, and running a cell executor on the virtual doc. That did not work out because I don't know how to set your cursor's position in a virtual doc and cell execution commands don't take positions as arguments.