### PR TITLE
Exclude headers in divs from outline

### DIFF
--- a/apps/lsp/src/service/toc.ts
+++ b/apps/lsp/src/service/toc.ts
@@ -36,6 +36,7 @@ import {
   getLine,
   Document,
   Parser,
+  isDiv,
 
 } from 'quarto-core';
 
@@ -140,7 +141,7 @@ export class TableOfContents {
     }
 
     // compute restricted ranges (ignore headings in these ranges)
-    const isWithinIgnoredRange = isWithinRange(tokens, token => isCallout(token) || isTheorem(token) || isProof(token));
+    const isWithinIgnoredRange = isWithinRange(tokens, isDiv);
     const isWithinTabset = isWithinRange(tokens, isTabset);
 
     const existingSlugEntries = new Map<string, { count: number }>();

--- a/packages/quarto-core/src/markdown/token.ts
+++ b/packages/quarto-core/src/markdown/token.ts
@@ -33,29 +33,29 @@ export type TokenType =
 export const kAttrIdentifier = 0;
 export const kAttrClasses = 1;
 export const kAttrAttributes = 2;
-export type TokenAttr = [string, Array<string>, Array<[string,string]>];
+export type TokenAttr = [string, Array<string>, Array<[string, string]>];
 
 
 export interface Token<T = unknown> {
   type: TokenType;
   range: Range;
-  attr?: TokenAttr; 
+  attr?: TokenAttr;
   data: T;
-    // FrontMatter: yaml
-    // Header: { level: number, text: string }
-    // Math: { type: string, text: string }
-    // CodeBlock: text
-    // RawBlock: { format: string, text: string }
-    // (Other): null
+  // FrontMatter: yaml
+  // Header: { level: number, text: string }
+  // Math: { type: string, text: string }
+  // CodeBlock: text
+  // RawBlock: { format: string, text: string }
+  // (Other): null
 }
 
 export type TokenFrontMatter = Token<string>;
-export function isFrontMatter(token: Token) : token is TokenFrontMatter {
+export function isFrontMatter(token: Token): token is TokenFrontMatter {
   return token.type === "FrontMatter";
 }
 
 export type TokenHeader = Token<{ level: number, text: string }>;
-export function isHeader(token: Token) : token is TokenHeader {
+export function isHeader(token: Token): token is TokenHeader {
   return token.type === "Header";
 }
 
@@ -72,6 +72,10 @@ export function isCodeBlock(token: Token): token is TokenCodeBlock {
 export type TokenRawBlock = Token<{ format: string, text: string }>;
 export function isRawBlock(token: Token): token is TokenRawBlock {
   return token.type === "RawBlock";
+}
+
+export function isDiv(token: Token) {
+  return token.type === "Div"
 }
 
 export function isCallout(token: Token) {


### PR DESCRIPTION
Fixes https://github.com/quarto-dev/quarto/issues/829

Some headers inside divs were already being excluded, but the exclusion rules were too conservative. The exclusions checked if the header was inside a callout (a div with a class that starts with `callout-`), a Theorem (a div with a theorem-specific id), or a Proof (a div with a proof-specific id). Now it excludes all headers inside any div.