### PR TITLE
Force a user save on untitled documents, before switch to visual mode

### DIFF
--- a/apps/vscode/src/providers/editor/toggle.ts
+++ b/apps/vscode/src/providers/editor/toggle.ts
@@ -123,6 +123,11 @@ export async function reopenEditorInVisualMode(
   if (hasHooks()) {
     // note pending switch to visual
     VisualEditorProvider.recordPendingSwitchToVisual(document);
+    // if document is untitled, force user to save first
+    if (document.isUntitled) {
+      await commands.executeCommand("workbench.action.files.save");
+    }
+    // reopen in visual mode
     commands.executeCommand('positron.reopenWith', document.uri, 'quarto.visualEditor');
   } else {
     // save then close


### PR DESCRIPTION
Addresses https://github.com/quarto-dev/quarto/issues/827

Untitled files cannot be edited in visual mode; we actually have a whole special set of screens to show people about this:

https://github.com/search?q=repo%3Aquarto-dev%2Fquarto%20untitled_document_cannot_be_edited&type=code

The new Positron-specific command we made to help with these switches `positron.reopenWith` is working generally well, but it doesn't know about this special Quarto rule. If we have an untitled document here, let's force the user to save before switching.