### PR TITLE
Hide diagnostics from virtual documents

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1045,6 +1045,13 @@
           "default": true,
           "markdownDescription": "Use reticulate to execute Python cells within Knitr engine documents."
         },
+        "quarto.vdoc.hideDiagnostics": {
+          "order": 26,
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Hide diagnostics (problems) reported for internal virtual document files. These are temporary files used to provide language features in code blocks."
+        },
         "quarto.mathjax.scale": {
           "order": 15,
           "scope": "window",

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -15,6 +15,7 @@
 
 import { Position, TextDocument, Uri, Range } from "vscode";
 import { Token, isExecutableLanguageBlock, languageBlockAtPosition, languageNameFromBlock } from "quarto-core";
+import * as path from "path";
 
 import { isQuartoDoc } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
@@ -51,6 +52,17 @@ export async function virtualDoc(
   } else {
     return undefined;
   }
+}
+
+export function isVirtualDoc(uri: Uri): boolean {
+  // Check for tempfile virtual docs
+  if (uri.scheme === "file") {
+    const filename = path.basename(uri.fsPath);
+    // Virtual docs have a specific filename pattern .vdoc.[uuid].[extension]
+    return filename.startsWith(".vdoc.") && filename.split(".").length > 3;
+  }
+
+  return false;
 }
 
 export function virtualDocForBlock(document: TextDocument, block: Token, language: EmbeddedLanguage) {


### PR DESCRIPTION
Addresses https://github.com/quarto-dev/quarto/issues/819, which has been quite a bear in real work! Many, many diagnostics from our `vdoc` files, every time you save a file with a syntax error in it. 😱 

It turns out the `Middleware` from "vscode-languageclient" already has a way to do `HandleDiagnosticsSignature`, so this was fairly straightforward.

I will get started on an extension test for this.