### PR TITLE
Dev configuration to insert semicolons on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,7 @@
     "editor.insertSpaces": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "javascript.format.semicolons": "insert",
+    "typescript.format.semicolons": "insert"
 }


### PR DESCRIPTION
If you are editing this repo in vscode or Positron, this setting makes it so semicolons are inserted on save.