### PR TITLE
Undo `onDidSaveTextDocument` that causes problems for ALL files in VS Code

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.126.0 (Unreleased)
 
+- Fixed a bug opening non-Quarto files in visual mode on saving (<https://github.com/quarto-dev/quarto/pull/848>).
+
 ## 1.125.0 (Release on 2025-09-03)
 
 - Fixed an issue where attribute values containing '='s could be truncated in some scenarios (<https://github.com/quarto-dev/quarto/pull/814>).

--- a/apps/vscode/src/providers/editor/toggle.ts
+++ b/apps/vscode/src/providers/editor/toggle.ts
@@ -129,18 +129,18 @@ export async function reopenEditorInVisualMode(
     // reopen in visual mode
     commands.executeCommand('positron.reopenWith', document.uri, 'quarto.visualEditor');
   } else {
-    workspace.onDidSaveTextDocument(async (doc: TextDocument) => {
-      // open in visual mode
-      VisualEditorProvider.recordPendingSwitchToVisual(doc);
-      await commands.executeCommand('workbench.action.closeActiveEditor');
-      await commands.executeCommand("vscode.openWith",
-        doc.uri,
-        VisualEditorProvider.viewType,
-        { viewColumn }
-      );
-    });
-    // save, which will trigger `onDidSaveTextDocument`
+    // save then close
     await commands.executeCommand("workbench.action.files.save");
+    await commands.executeCommand('workbench.action.closeActiveEditor');
+    VisualEditorProvider.recordPendingSwitchToVisual(document);
+
+    // open in visual mode
+    await commands.executeCommand(
+      "vscode.openWith",
+      document.uri,
+      VisualEditorProvider.viewType,
+      { viewColumn }
+    );
   }
 }
 


### PR DESCRIPTION
Addresses https://github.com/quarto-dev/quarto/issues/845

This PR undoes the change in https://github.com/quarto-dev/quarto/commit/6b416d3e59164cb4bb03e41664e286bc195b83bc that accidentally set up `onDidSaveTextDocument` that applies to _all_ documents. This bug was in a code path that only applied to VS Code.