### PR TITLE
Add test to check that the extension does not cause issues with non-qmd files

### DIFF
--- a/apps/vscode/src/test/examples/hello.lua
+++ b/apps/vscode/src/test/examples/hello.lua
@@ -1,0 +1,1 @@
+print("Hello World")

--- a/apps/vscode/src/test/quartoDoc.test.ts
+++ b/apps/vscode/src/test/quartoDoc.test.ts
@@ -41,6 +41,20 @@ suite("Quarto basics", function () {
   roundtripSnapshotTest('capsule-leak.qmd');
 
   roundtripSnapshotTest('attr-equals.qmd');
+
+  // a test to prevent situations like https://github.com/quarto-dev/quarto/issues/845
+  test("Can open a non-qmd file normally", async function () {
+    const { editor, doc } = await openAndShowTextDocument("hello.lua");
+
+    editor.edit((editBuilder) => {
+      editBuilder.insert(new vscode.Position(0, 0), 'print("hiyo")\n');
+    });
+    doc.save();
+
+    await wait(1700); // approximate time to open visual editor, just in case
+
+    assert.equal(vscode.window.activeTextEditor, editor, 'quarto extension interferes with other files opened in VSCode!');
+  });
 });
 
 /**


### PR DESCRIPTION
This test is added to prevent situations like https://github.com/quarto-dev/quarto/issues/845 in which [code was added to the extension](https://github.com/quarto-dev/quarto/commit/6b416d3e59164cb4bb03e41664e286bc195b83bc) that caused non-qmd text files to be closed and re-opened in the visual editor (very bad).

The test checks that a `.lua` file can be opened, edited, and saved and afterwards is still open as the active editor in VSCode. I "red-light/green-light"'d the test (made sure it failed when I checked out v1.125, the version with the problem, and passed when I checked out v1.126, the version with the fix).

We could make this test catch other similar types of issues, but this seems like the simplest way to catch issues like #845 where saving a non-qmd file messes with the active VSCode editor.