### PR TITLE
Fix incorrect refactor of `provideStatementRange`

### DIFF
--- a/apps/vscode/src/host/hooks.ts
+++ b/apps/vscode/src/host/hooks.ts
@@ -169,7 +169,7 @@ class EmbeddedStatementRangeProvider implements HostStatementRangeProvider {
         const result = await vscode.commands.executeCommand<hooks.StatementRange>(
           "vscode.executeStatementRangeProvider",
           uri,
-          position
+          adjustedPosition(vdoc.language, position)
         );
         return { range: unadjustedRange(vdoc.language, result.range), code: result.code };
       });


### PR DESCRIPTION
In #825 @juliasilge noticed that statement execution was broken in Positron source editor for python code cells. I tracked down the issue to a refactor in my previous PR #857.

In #857 I attempted to refactor `provideStatementRange`. The refactor consisted of inlining a function into another. I made a mistake while inlining, leaving some important code behind. @juliasilge noticed that the change was breaking (see https://github.com/quarto-dev/quarto/pull/857#discussion_r2464150675), and I attempted to address the mistake. I fixed the mistake, adding back in the missing code, but in the process I accidentally introduced another mistake: using `position` instead of `adjustedPosition(vdoc.language, position)`.

I have tested this PR and it fixes statement range execution in Positron source editor for python code cells.

Next time I do a refactor, I need to find ways to be more systematic about it. It also motivates me to set up some infrastructure for source-mode tests for statement and cell execution. For now, I will put up a small PR to fix the problem.