### PR TITLE
Revamp the extension README

### DIFF
--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -9,7 +9,7 @@ This extension provides language support for Quarto `.qmd` files for both [VS Co
 Use the functionality provided in this extension to:
 
 - Author Quarto documents with enhanced editing features such as syntax highlighting, code completion, diagnostics, specialized code snippets, and document navigation
-- Use the Visual Editor for WYSIWYG editing of Quarto documents
+- Use the Visual Editor for [WYSIWYM](https://en.wikipedia.org/wiki/WYSIWYM) editing of Quarto documents
 - Execute code cells interactively
 - Render and preview Quarto documents to multiple formats
 


### PR DESCRIPTION
This PR makes some significant changes to the README, which had not been substantively edited since 2023. We don't touch this a lot, so I'd like this to be something that we feel good about being more minimal so we don't have it in the loop of our doc updates really regularly.

This is the file that shows up on these pages:

- https://marketplace.visualstudio.com/items?itemName=quarto.quarto
- https://open-vsx.org/extension/quarto/quarto

And in product here:

<img width="1597" height="1031" alt="Screenshot 2026-01-14 at 1 58 37 PM" src="https://github.com/user-attachments/assets/6bb1d27c-2889-48f0-8193-a64a7356e850" />

I will admit that I am doing a bit of Positron prioritization here, but I don't think it's inappropriate, given the balance of Positron vs. VS Code use of the extension these days. 