### PR TITLE
Fix mistake where changelog entry has added under old release heading

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.129.0 (Unreleased)
 
 - Fixed Copilot completions in `.qmd` documents (<https://github.com/quarto-dev/quarto/pull/887>).
-- Fixed a bug where the `autoDetectColorScheme` setting could cause equation previews to have a dark text on dark background and vice versa (<https://github.com/quarto-dev/quarto/pull/864/changes>).
+- Fixed a bug where the `autoDetectColorScheme` setting could cause equation previews to have a dark text on dark background and vice versa (<https://github.com/quarto-dev/quarto/pull/864>).
 
 ## 1.128.0 (Release on 2026-01-08)
 


### PR DESCRIPTION
I accidentally added #861's changelog entry under the previous release's (1.128) heading. Correcting that mistake