### PR TITLE
Terminate Quarto preview when terminal is closed externally

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for Positron's statement execution feature that reports the approximate line number of the parse error (<https://github.com/quarto-dev/quarto/pull/919>).
 - Fixed a bug where `Quarto: Format Cell` would notify you that no formatter was available for code cells that were already formatted (<https://github.com/quarto-dev/quarto/pull/933>).
 - No longer claim `.typ` files. Typst syntax highlighting in Quarto documents is unaffected, but standalone Typst files are now left to dedicated extensions like Tinymist (<https://github.com/quarto-dev/quarto/pull/943>).
+- Fixed a bug where closing the Quarto Preview terminal via the trash icon did not clean up intermediate `.quarto_ipynb` files (<https://github.com/quarto-dev/quarto/pull/947>).
 
 ## 1.130.0 (Release on 2026-02-18)
 

--- a/apps/vscode/src/providers/preview/preview.ts
+++ b/apps/vscode/src/providers/preview/preview.ts
@@ -282,6 +282,18 @@ class PreviewManager {
       this.outputSink_,
       this.renderToken_
     );
+
+    // When the user closes the preview terminal via the trash icon (or any
+    // external means), send the HTTP termination request so Quarto can clean
+    // up temp files (e.g. _ipynb files created during Python preview).
+    context.subscriptions.push(
+      vscode.window.onDidCloseTerminal(async (closedTerminal) => {
+        if (closedTerminal === this.terminal_) {
+          this.terminal_ = undefined;
+          await this.previewTerminateRequest();
+        }
+      })
+    );
   }
 
   dispose() {
@@ -416,6 +428,9 @@ class PreviewManager {
   }
 
   private async killPreview() {
+    // Clear this.terminal_ before disposing so the onDidCloseTerminal listener
+    // does not send a duplicate termination request.
+    this.terminal_ = undefined;
     await killTerminal(kPreviewWindowTitle, async () => await this.previewTerminateRequest());
     this.progressDismiss();
     this.progressCancellationToken_ = undefined;


### PR DESCRIPTION
Addresses posit-dev/positron#13006.

When a user closes the Quarto Preview terminal via the trash icon, the underlying Quarto process was not terminated cleanly. This left behind intermediate `.quarto_ipynb` files, and repeated previews would accumulate `*.quarto_ipynb_1`, `*.quarto_ipynb_2`, etc.

This was happening because VS Code's trash icon sends `SIGHUP` to the shell process only. Quarto, as a child process, typically survives as an orphan and never receives the signal needed to trigger cleanup. <kbd>Ctrl+C</kbd> works because it sends `SIGINT` to the entire foreground process group.

This PR registers an `onDidCloseTerminal` listener in `PreviewManager`. When the preview terminal is closed by any external means, it sends the same HTTP termination request that `killPreview()` already uses, giving Quarto the chance to clean up before it exits. To avoid a duplicate request when the extension itself kills the terminal, `this.terminal_` is cleared before `killTerminal()` is called, so the event handler's identity check short-circuits.
