### PR TITLE
Use Positron's active runtime when inserting a code cell

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added clickable document links for file paths in `_quarto.yml` files. File paths are now clickable and navigate directly to the referenced file (<https://github.com/quarto-dev/quarto/pull/906>).
 - Added filepath autocompletion in `_quarto.yml` files. When editing YAML values, the extension now suggests project files as you type (<https://github.com/quarto-dev/quarto/pull/906>).
-- Now use Positron's active runtime to choose the language for new code cells in an empty document (<https://github.com/quarto-dev/quarto/pull/951>).
+- In an empty document, Positron's active runtime is now used to choose the language for a new code cell (<https://github.com/quarto-dev/quarto/pull/951>).
 
 ## 1.131.0 (Release on 2026-04-14)
 

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added clickable document links for file paths in `_quarto.yml` files. File paths are now clickable and navigate directly to the referenced file (<https://github.com/quarto-dev/quarto/pull/906>).
 - Added filepath autocompletion in `_quarto.yml` files. When editing YAML values, the extension now suggests project files as you type (<https://github.com/quarto-dev/quarto/pull/906>).
+- Now use Positron's active runtime to choose the language for new code cells in an empty document (<https://github.com/quarto-dev/quarto/pull/951>).
 
 ## 1.131.0 (Release on 2026-04-14)
 

--- a/apps/vscode/src/@types/hooks.d.ts
+++ b/apps/vscode/src/@types/hooks.d.ts
@@ -13,6 +13,12 @@ declare module 'positron' {
 		StatementRangeSyntaxError: typeof StatementRangeSyntaxError;
 	}
 
+	export interface LanguageRuntimeSession {
+		readonly runtimeMetadata: {
+			readonly languageId: string;
+		};
+	}
+
 	export interface PositronRuntime {
 		executeCode(
 			languageId: string,
@@ -25,6 +31,8 @@ declare module 'positron' {
 			documentUri: vscode.Uri,
 			cellRanges: vscode.Range[]
 		): Thenable<void>;
+
+		getForegroundSession(): Thenable<LanguageRuntimeSession | undefined>;
 	}
 
 	export interface PositronLanguages {

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -116,7 +116,7 @@ class InsertCodeCellCommand implements Command {
         if (language) {
           header = "```{" + language + "}";
         } else {
-          header = "
+          header = "```{${1|" + languages.join(",") + "|}}";
         }
 
         // insert snippet

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -22,8 +22,7 @@ import {
 import { Command } from "../core/command";
 import { isQuartoDoc } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
-import { tryAcquirePositronApi } from "@posit-dev/positron";
-import type { PositronApi } from "positron";
+import { hooksApi } from "../host/hooks";
 import { isExecutableLanguageBlock, languageBlockAtPosition, languageNameFromBlock } from "quarto-core";
 
 
@@ -103,8 +102,7 @@ class InsertCodeCellCommand implements Command {
         // if no language found in document, fall back to Positron's active runtime
         const kSupportedLanguages = ['python', 'r', 'julia', 'ojs', 'sql', 'bash', 'mermaid', 'dot'];
         if (!language) {
-          const api = tryAcquirePositronApi() as unknown as PositronApi | undefined;
-          const session = await api?.runtime.getForegroundSession();
+          const session = await hooksApi()?.runtime.getForegroundSession();
           const sessionLang = session?.runtimeMetadata.languageId ?? "";
           if (kSupportedLanguages.includes(sessionLang)) {
             language = sessionLang;

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -100,11 +100,11 @@ class InsertCodeCellCommand implements Command {
         }
 
         // if no language found in document, fall back to Positron's active runtime
-        const kSupportedLanguages = ['python', 'r', 'julia', 'ojs', 'sql', 'bash', 'mermaid', 'dot'];
+        const languages = ['python', 'r', 'julia', 'ojs', 'sql', 'bash', 'mermaid', 'dot'];
         if (!language) {
           const session = await hooksApi()?.runtime.getForegroundSession();
           const sessionLang = session?.runtimeMetadata.languageId ?? "";
-          if (kSupportedLanguages.includes(sessionLang)) {
+          if (languages.includes(sessionLang)) {
             language = sessionLang;
           }
         }
@@ -116,7 +116,7 @@ class InsertCodeCellCommand implements Command {
         if (language) {
           header = "```{" + language + "}";
         } else {
-          header = "```{${1|" + kSupportedLanguages.join(",") + "|}}";
+          header = "
         }
 
         // insert snippet

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -22,6 +22,8 @@ import {
 import { Command } from "../core/command";
 import { isQuartoDoc } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
+import { tryAcquirePositronApi } from "@posit-dev/positron";
+import type { PositronApi } from "positron";
 import { isExecutableLanguageBlock, languageBlockAtPosition, languageNameFromBlock } from "quarto-core";
 
 
@@ -98,6 +100,17 @@ class InsertCodeCellCommand implements Command {
           }
         }
 
+        // if no language found in document, fall back to Positron's active runtime
+        const kSupportedLanguages = ['python', 'r', 'julia', 'ojs', 'sql', 'bash', 'mermaid', 'dot'];
+        if (!language) {
+          const api = tryAcquirePositronApi() as unknown as PositronApi | undefined;
+          const session = await api?.runtime.getForegroundSession();
+          const sessionLang = session?.runtimeMetadata.languageId ?? "";
+          if (kSupportedLanguages.includes(sessionLang)) {
+            language = sessionLang;
+          }
+        }
+
         // if we have a known language, use it and put the cursor directly in the
         // code cell, otherwise let the user select the language first
         let header;
@@ -105,8 +118,7 @@ class InsertCodeCellCommand implements Command {
         if (language) {
           header = "```{" + language + "}";
         } else {
-          const languages = ['python', 'r', 'julia', 'ojs', 'sql', 'bash', 'mermaid', 'dot'];
-          header = "```{${1|" + languages.join(",") + "|}}";
+          header = "```{${1|" + kSupportedLanguages.join(",") + "|}}";
         }
 
         // insert snippet

--- a/apps/vscode/src/test/insert.test.ts
+++ b/apps/vscode/src/test/insert.test.ts
@@ -1,0 +1,96 @@
+import * as vscode from "vscode";
+import * as assert from "assert";
+import { examplesOutUri, openAndShowExamplesOutTextDocument, WORKSPACE_PATH } from "./test-utils";
+
+suite("Insert Code Cell", function () {
+  suiteSetup(async function () {
+    await vscode.workspace.fs.delete(examplesOutUri(), { recursive: true });
+    await vscode.workspace.fs.copy(vscode.Uri.file(WORKSPACE_PATH), examplesOutUri());
+  });
+
+  teardown(async function () {
+    await vscode.commands.executeCommand("undo");
+  });
+
+  // format/basics.qmd (0-indexed lines):
+  //   9:  ```{python}
+  //   10: x = 1 + 1       <- inside python block
+  //   11: ```
+  //   13: More markdown text.  <- between blocks
+  //   15: ```{r}
+  //   16: y <- 1 + 1      <- inside r block
+  //   17: ```
+  //   19: Final line.     <- after all blocks
+  //    7: Some regular text here.  <- before all blocks
+
+  suite("Language from cursor context", function () {
+    test("Uses language of block when cursor is inside a Python block", async function () {
+      const { doc, editor } = await openAndShowExamplesOutTextDocument("format/basics.qmd");
+      const before = countOccurrences(doc.getText(), "```{python}");
+
+      editor.selection = new vscode.Selection(10, 0, 10, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(countOccurrences(doc.getText(), "```{python}"), before + 1);
+    });
+
+    test("Uses language of block when cursor is inside an R block", async function () {
+      const { doc, editor } = await openAndShowExamplesOutTextDocument("format/basics.qmd");
+      const before = countOccurrences(doc.getText(), "```{r}");
+
+      editor.selection = new vscode.Selection(16, 0, 16, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(countOccurrences(doc.getText(), "```{r}"), before + 1);
+    });
+
+    test("Uses language of nearest preceding block when cursor is between blocks", async function () {
+      const { doc, editor } = await openAndShowExamplesOutTextDocument("format/basics.qmd");
+      const before = countOccurrences(doc.getText(), "```{python}");
+
+      editor.selection = new vscode.Selection(13, 0, 13, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(countOccurrences(doc.getText(), "```{python}"), before + 1);
+    });
+
+    test("Uses language of first following block when cursor precedes all blocks", async function () {
+      const { doc, editor } = await openAndShowExamplesOutTextDocument("format/basics.qmd");
+      const before = countOccurrences(doc.getText(), "```{python}");
+
+      editor.selection = new vscode.Selection(7, 0, 7, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(countOccurrences(doc.getText(), "```{python}"), before + 1);
+    });
+
+    test("Uses language of last block when cursor follows all blocks", async function () {
+      const { doc, editor } = await openAndShowExamplesOutTextDocument("format/basics.qmd");
+      const before = countOccurrences(doc.getText(), "```{r}");
+
+      editor.selection = new vscode.Selection(19, 0, 19, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(countOccurrences(doc.getText(), "```{r}"), before + 1);
+    });
+  });
+
+  suite("Language picker fallback", function () {
+    test("Inserts a code fence when document has no executable code cells", async function () {
+      const content = "---\ntitle: Test\n---\n\nJust some markdown.\n";
+      const uri = examplesOutUri("insert-test-empty.qmd");
+      await vscode.workspace.fs.writeFile(uri, Buffer.from(content, "utf8") as Uint8Array);
+
+      const doc = await vscode.workspace.openTextDocument(uri);
+      const editor = await vscode.window.showTextDocument(doc);
+      editor.selection = new vscode.Selection(4, 0, 4, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.ok(doc.getText().includes("```{"));
+    });
+  });
+});
+
+function countOccurrences(text: string, substring: string): number {
+  return text.split(substring).length - 1;
+}


### PR DESCRIPTION
Closes #480

When using _Insert Code Cell_ in source mode, the extension determines the language for the new cell using a priority chain:

1. **Cursor is inside an existing code cell:** use that cell's language and move the cursor to just after the block.
2. **Cursor is outside any code cell, but the document has executable blocks:** use the language of the nearest block (the last one before the cursor, or the first one after if there are none before).
3. **No executable blocks in the document, and running in Positron:** (new, this PR) call `positron.runtime.getForegroundSession()` to get the active runtime's language. If it's one of the supported Quarto languages (`python`, `r`, `julia`, `ojs`, `sql`, `bash`, `mermaid`, `dot`), that language is used.
4. **None of the above:** fall back to an interactive snippet picker listing all supported languages.

Steps 1 to 3 all result in the cursor being placed directly inside the new cell (no picker). Step 4 requires the user to make a selection first.

This is a Positron-only improvement; in VS Code, step 3 is skipped and the picker appears for any empty document.