### PR TITLE
`quarto preview` in a terminal with a venv: increase wait time to 5s

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Send cell figure options (width/height) to Positron to control sizing in its Plots pane (<https://github.com/quarto-dev/quarto/pull/938>).
 - Added "Convert to .ipynb" and "Convert to .qmd" commands for converting between Quarto documents and Jupyter notebooks (<https://github.com/quarto-dev/quarto/pull/955>)
 - Guard against empty `config` field in `quarto inspect` which might happen in some circumstances in Quarto 1.9 (<https://github.com/quarto-dev/quarto/pull/961>)
+- Increase timeout to run `quarto preview` in a terminal with a Python virtual environment to 5s, to work around VS code injecting shell commands after `quarto preview` started (<https://github.com/quarto-dev/quarto/pull/962>)
 
 ## 1.131.0 (Release on 2026-04-14)
 

--- a/apps/vscode/src/core/terminal.ts
+++ b/apps/vscode/src/core/terminal.ts
@@ -169,7 +169,7 @@ function requiredTerminalDelay(env?: TerminalEnv): number {
   try {
     if (env?.QUARTO_PYTHON) {
       if (pythonIsVenv(env.QUARTO_PYTHON)) {
-        return 1000;
+        return 5000;
       } else if (pythonIsCondaEnv(env.QUARTO_PYTHON)) {
         return 5000;
       } else {

--- a/apps/vscode/src/core/terminal.ts
+++ b/apps/vscode/src/core/terminal.ts
@@ -169,7 +169,7 @@ function requiredTerminalDelay(env?: TerminalEnv): number {
   try {
     if (env?.QUARTO_PYTHON) {
       if (pythonIsVenv(env.QUARTO_PYTHON)) {
-        return 5000;
+        return 5000; // magic number found with trial&error to avoid command clobbering
       } else if (pythonIsCondaEnv(env.QUARTO_PYTHON)) {
         return 5000;
       } else {


### PR DESCRIPTION
This attempts to work around vscode clobbering the preview command; recent versions appear to inject shell commands after `quarto preview` started, which completely breaks the preview command. The 5s timeout was not determined with any level of rigor, but does consistently solve the problem in my environment.