### PR TITLE
Update `yarn dev-vscode` to build tests with `dev` mode (i.e. watch and recompile)

### DIFF
--- a/apps/vscode/build.ts
+++ b/apps/vscode/build.ts
@@ -26,6 +26,7 @@ const testBuildOptions = {
   outdir: 'test-out',
   external: ['vscode', 'mocha', 'glob'],
   sourcemap: true,
+  dev,
 };
 
 const defaultBuildOptions = {
@@ -36,4 +37,11 @@ const defaultBuildOptions = {
   dev
 };
 
-runBuild(test ? testBuildOptions : defaultBuildOptions);
+if (test) {
+  runBuild(testBuildOptions);
+} else if (dev) {
+  runBuild(defaultBuildOptions);
+  runBuild(testBuildOptions);
+} else {
+  runBuild(defaultBuildOptions);
+}

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -13,8 +13,9 @@
  *
  */
 
-import { build, Format, Platform } from 'esbuild';
+import { build, Format, Platform, PluginBuild } from 'esbuild';
 import { AssetPair, copy } from 'esbuild-plugin-copy';
+import { rm } from 'node:fs/promises';
 
 export interface BuildOptions {
   entryPoints: string[];
@@ -58,17 +59,27 @@ export async function runBuild(options: BuildOptions) {
     watch: dev ? {
       onRebuild(error) {
         if (error)
-          console.error('[watch] build failed:', error)
+          console.error('[watch] build failed:', error);
         else
-          console.log('[watch] build finished')
+          console.log('[watch] build finished');
       },
     } : false,
-    plugins: assets ? [
-      copy({
+    plugins: [
+      ...(outdir ? [{
+        name: 'clear-outdir',
+        setup(build: PluginBuild) {
+          build.onStart(async () => {
+            console.log(`Clearing the ${outdir} directory`);
+            await rm(outdir, { recursive: true, force: true });
+            console.log(`Cleared the ${outdir} directory`);
+          });
+        },
+      }] : []),
+      ...(assets ? [copy({
         resolveFrom: 'cwd',
         assets,
-      }),
-    ] : [],
+      })] : []),
+    ],
   });
 
   if (dev) {


### PR DESCRIPTION
Previously, if you ran the VS Code extension's tests from the test pane it would not trigger a recompile and would run stale tests. You had to use `yarn test-vscode`.

This PR updates `yarn dev-vscode` (more specifically, `apps/vscode/build.ts`) to also build tests with `dev` mode (i.e. a watch server that automatically recompiles).