### PR TITLE
Bump version and changelog

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.134.0 (Unreleased)
+
 ## 1.133.0 (Release on 2026-06-03)
 
 - Added diagnostics (i.e. squiggly underlines) to code cells in qmds (<https://github.com/quarto-dev/quarto/pull/980>).

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -11,7 +11,7 @@
     "pandoc",
     "quarto"
   ],
-  "version": "1.133.0",
+  "version": "1.134.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode"


### PR DESCRIPTION
Bump to the next version of the extension, 1.134