### PR TITLE
Add getSelectedText to the visual editor

### DIFF
--- a/apps/vscode-editor/src/sync.ts
+++ b/apps/vscode-editor/src/sync.ts
@@ -36,6 +36,7 @@ import {
   VSC_VE_GetSlideIndex,
   VSC_VE_GetActiveBlockContext,
   VSC_VE_SetBlockSelection,
+  VSC_VE_GetSelectedText,
   VSC_VE_Init, 
   VSC_VE_Focus,
   VSC_VEH_FlushEditorUpdates,
@@ -252,6 +253,9 @@ export async function syncEditorToHost(
     },
     async setBlockSelection(context: CodeViewActiveBlockContext, action: CodeViewSelectionAction) {
       editor.setBlockSelection(context, action);
+    },
+    async getSelectedText(): Promise<string> {
+      return editor.getSelectedText();
     }
   })
 
@@ -334,6 +338,7 @@ function visualEditorHostServer(vscode: WebviewApi<unknown>, editor: VSCodeVisua
     [VSC_VE_ApplyExternalEdit]: args => editor.applyExternalEdit(args[0]),
     [VSC_VE_GetActiveBlockContext]: () => editor.getActiveBlockContext(),
     [VSC_VE_SetBlockSelection]: args => editor.setBlockSelection(args[0], args[1]),
+    [VSC_VE_GetSelectedText]: () => editor.getSelectedText(),
     [VSC_VE_PrefsChanged]: args => editor.prefsChanged(args[0]),
     [VSC_VE_ImageChanged]: args => editor.imageChanged(args[0])
   })

--- a/apps/vscode/src/providers/editor/connection.ts
+++ b/apps/vscode/src/providers/editor/connection.ts
@@ -25,6 +25,7 @@ import {
   VSC_VE_ApplyExternalEdit,
   VSC_VE_GetActiveBlockContext,
   VSC_VE_SetBlockSelection,
+  VSC_VE_GetSelectedText,
   VSC_VEH_EditorResourceUri,
   VSC_VEH_GetHostContext,
   VSC_VEH_ReopenSourceMode,
@@ -88,6 +89,7 @@ export function visualEditorClient(webviewPanel: WebviewPanel)
         context: CodeViewActiveBlockContext,
         action: CodeViewSelectionAction
       ) => request(VSC_VE_SetBlockSelection, [context, action]),
+      getSelectedText: () => request(VSC_VE_GetSelectedText, []),
       applyExternalEdit: (markdown: string) => request(VSC_VE_ApplyExternalEdit, [markdown]),
       prefsChanged: (prefs: Prefs) => request(VSC_VE_PrefsChanged, [prefs]),
       imageChanged: (file: string) => request(VSC_VE_ImageChanged, [file])

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -74,6 +74,7 @@ export interface QuartoVisualEditor extends QuartoEditor {
   hasFocus(): Promise<boolean>;
   getActiveBlockContext(): Promise<CodeViewActiveBlockContext | null>;
   setBlockSelection(context: CodeViewActiveBlockContext, action: CodeViewSelectionAction): Promise<void>;
+  getSelectedText(): Promise<string>;
 }
 
 export function activateEditor(
@@ -98,6 +99,16 @@ export function activateEditor(
       id: 'quarto.test_isInVisualEditor',
       execute() {
         return VisualEditorProvider.activeEditor() !== undefined;
+      }
+    },
+    {
+      id: 'quarto.editor.getSelectedText',
+      async execute() {
+        const editor = VisualEditorProvider.activeEditor(true);
+        if (editor) {
+          return await editor.getSelectedText();
+        }
+        return '';
       }
     },
     editInVisualModeCommand(),
@@ -302,6 +313,9 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
         },
         setBlockSelection: async (context, action) => {
           await editor.editor.setBlockSelection(context, action);
+        },
+        getSelectedText: async () => {
+          return await editor.editor.getSelectedText();
         },
         viewColumn: editor.webviewPanel.viewColumn
       };

--- a/packages/editor-types/src/vscode.ts
+++ b/packages/editor-types/src/vscode.ts
@@ -31,6 +31,7 @@ export const VSC_VE_PrefsChanged = 'vsc_ve_prefs_changed';
 export const VSC_VE_ImageChanged = 'vsc_ve_image_changed';
 export const VSC_VE_GetActiveBlockContext = 'vsc_ve_get_active_block_context';
 export const VSC_VE_SetBlockSelection = 'vsc_ve_set_block_selection';
+export const VSC_VE_GetSelectedText = 'vsc_ve_get_selected_text';
 
 export const VSC_VEH_GetHostContext = 'vsc_ve_get_host_context';
 export const VSC_VEH_ReopenSourceMode = 'vsc_ve_reopen_source_mode';
@@ -60,6 +61,7 @@ export interface VSCodeVisualEditor {
   getSlideIndex: () => Promise<number>;
   getActiveBlockContext: () => Promise<CodeViewActiveBlockContext | null>;
   setBlockSelection: (context: CodeViewActiveBlockContext, action: CodeViewSelectionAction) => Promise<void>;
+  getSelectedText: () => Promise<string>;
   applyExternalEdit: (markdown: string) => Promise<void>;
   prefsChanged: (prefs: Prefs) => Promise<void>;
   imageChanged: (file: string) => Promise<void>;

--- a/packages/editor-ui/src/editor/Editor.tsx
+++ b/packages/editor-ui/src/editor/Editor.tsx
@@ -328,6 +328,9 @@ export const Editor : React.FC<EditorProps> = (props) => {
     setBlockSelection(context, action) {
       editorRef.current!.setBlockSelection(context, action);
     },
+    getSelectedText() {
+      return editorRef.current!.getSelectedText();
+    },
     getFindReplace() {
       return editorRef.current?.getFindReplace();
     },

--- a/packages/editor/src/editor/editor.ts
+++ b/packages/editor/src/editor/editor.ts
@@ -302,6 +302,9 @@ export interface EditorOperations {
   getCodeViewActiveBlockContext() : CodeViewActiveBlockContext | undefined;
   setBlockSelection(context: CodeViewActiveBlockContext, action: CodeViewSelectionAction) : void;
 
+  // selection
+  getSelectedText() : string;
+
   // subsystems
   getFindReplace() : EditorFindReplace | undefined
 
@@ -791,7 +794,9 @@ export class Editor  {
   }
 
   public getSelectedText(): string {
-    return this.state.doc.textBetween(this.state.selection.from, this.state.selection.to);
+    const { from, to } = this.state.selection;
+    if (from === to) return '';
+    return this.state.doc.textBetween(from, to, '\n\n', '');
   }
 
   public replaceSelection(value: string): void {


### PR DESCRIPTION
## Summary

Exposes the visual editor's current text selection through the full RPC stack so the host extension can read what the user has selected in the visual editor.

The change plumbs a new `getSelectedText()` method through each layer:

- `EditorOperations.getSelectedText()` and the `Editor` implementation (`packages/editor`)
- The `EditorOperations` object built in `Editor.tsx` (`packages/editor-ui`)
- The `VSCodeVisualEditor` interface and the `VSC_VE_GetSelectedText` RPC constant (`packages/editor-types`)
- The webview host server and client transport (`apps/vscode-editor/sync.ts`, `apps/vscode/.../connection.ts`)
- A new `quarto.editor.getSelectedText` command that returns the selection, or `''` when no visual editor is active (`apps/vscode/.../editor.ts`)

It also tightens `Editor.getSelectedText()` to join blocks with `\n\n` and return `''` for an empty selection (previously it concatenated block text with no separator).

## Test plan

- [ ] Build the VS Code extension (`yarn build-vscode`)
- [ ] Open a document in the visual editor, select text, and invoke `quarto.editor.getSelectedText` — verify it returns the selection
- [ ] Verify it returns `''` when no visual editor is active and when the selection is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)