### PR TITLE
fix: render in positron notebook

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - In Positron, Jupyter Notebooks (`.ipynb`) are now exported via the new unified "Export" command, rather than the "Quarto: Convert to .qmd" command (<https://github.com/quarto-dev/quarto/pull/999>).
 - Fixed a bug where formatting a code cell stripped leading empty lines. Leading empty lines between option directives and code are now preserved, and two or more leading empty lines are collapsed to one (<https://github.com/quarto-dev/quarto/pull/953>).
 - Fixed a bug where IPython magics (`%`, `%%`) and shell escapes (`!`) in Python code cells produced spurious diagnostics from language servers like Pyrefly and Ruff. These lines are now commented out in the virtual document handed to language servers (<https://github.com/quarto-dev/quarto/pull/1013>).
+- The "Render Document" command is now available in the Positron Notebook Editor (<https://github.com/quarto-dev/quarto/pull/1002>).
 
 ## 1.133.0 (Release on 2026-06-03)
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -798,7 +798,7 @@
         },
         {
           "command": "quarto.renderDocument",
-          "when": "editorLangId == quarto ||  editorLangId == markdown || activeEditor == 'workbench.editor.notebook' || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
+          "when": "editorLangId == quarto ||  editorLangId == markdown || resourceExtname == .ipynb || activeEditor == 'workbench.editor.notebook' || activeCustomEditorId == 'quarto.visualEditor' || quartoRenderDocActive"
         },
         {
           "command": "quarto.previewScript",


### PR DESCRIPTION
Enable "Render Document" in all .ipynb editor tabs. Related to https://github.com/posit-dev/positron/issues/9792.

Here's what it looks like in the Positron Notebook Editor:

<img width="1097" height="1048" alt="image" src="https://github.com/user-attachments/assets/cf5c4d31-16d9-434f-8271-b69ae094b547" />