### PR TITLE
Comment out IPython magics in Python virtual documents to avoid spurious diagnostics

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The "Preview" and "Preview Format..." commands now show in the Positron Notebook Editor overflow menu (<https://github.com/quarto-dev/quarto/pull/1001>).
 - In Positron, Jupyter Notebooks (`.ipynb`) are now exported via the new unified "Export" command, rather than the "Quarto: Convert to .qmd" command (<https://github.com/quarto-dev/quarto/pull/999>).
 - Fixed a bug where formatting a code cell stripped leading empty lines. Leading empty lines between option directives and code are now preserved, and two or more leading empty lines are collapsed to one (<https://github.com/quarto-dev/quarto/pull/953>).
+- Fixed a bug where IPython magics (`%`, `%%`) and shell escapes (`!`) in Python code cells produced spurious diagnostics from language servers like Pyrefly and Ruff. These lines are now commented out in the virtual document handed to language servers (<https://github.com/quarto-dev/quarto/pull/1013>).
 
 ## 1.133.0 (Release on 2026-06-03)
 

--- a/apps/vscode/src/test/examples/.gitignore
+++ b/apps/vscode/src/test/examples/.gitignore
@@ -1,2 +1,3 @@
 *.html
 *_files
+.quarto/

--- a/apps/vscode/src/test/examples/generated_snapshots/vdoc/magics-python.py
+++ b/apps/vscode/src/test/examples/generated_snapshots/vdoc/magics-python.py
@@ -1,0 +1,25 @@
+# type: ignore
+# flake8: noqa
+#
+#
+#
+#
+#
+#
+#
+#
+import pandas as pd
+
+#
+#
+#
+#
+x = 1
+#
+#
+#
+#
+#
+#
+#
+#

--- a/apps/vscode/src/test/examples/vdoc/magics.qmd
+++ b/apps/vscode/src/test/examples/vdoc/magics.qmd
@@ -1,0 +1,20 @@
+---
+title: "IPython magics and shell escapes in code cells"
+format: html
+---
+
+## Header
+
+```{python}
+import pandas as pd
+
+%reload_ext pandas
+%%timeit
+!pip install pandas
+  %time x = 1
+x = 1
+```
+
+```{r}
+1 + 1
+```

--- a/apps/vscode/src/test/vdoc.test.ts
+++ b/apps/vscode/src/test/vdoc.test.ts
@@ -31,6 +31,16 @@ suite("Virtual documents", function () {
     VirtualDocStyle.Block
   );
 
+  // IPython magics (`%`, `%%`) and shell escapes (`!`) should be commented out
+  // in Python virtual documents so they don't produce spurious diagnostics.
+  snapshotVirtualDocument(
+    "vdoc/magics-python.py",
+    "vdoc/magics.qmd",
+    new vscode.Position(8, 0),
+    engine,
+    VirtualDocStyle.Language
+  );
+
   test("OOB position returns `undefined` virtual doc", async function () {
     const { doc } = await openAndShowExamplesTextDocument("vdoc/oob.qmd");
 

--- a/apps/vscode/src/vdoc/languages.ts
+++ b/apps/vscode/src/vdoc/languages.ts
@@ -29,6 +29,12 @@ export interface EmbeddedLanguage {
    * created for non-diagnostic actions.
    */
   inject?: string[];
+  /**
+   * Comment out IPython magics (`%`, `%%`) and shell escapes (`!`) in the
+   * virtual document so they don't produce spurious diagnostics from language
+   * servers. Applies to IPython-flavored languages such as Python.
+   */
+  commentMagics?: boolean;
   canFormat?: boolean;
   canFormatDocument?: boolean;
 }
@@ -47,6 +53,7 @@ const kEmbededLanguages = [
   defineLanguage("python", {
     inject: ["# type: ignore", "# flake8: noqa"],
     emptyLine: "#",
+    commentMagics: true,
     canFormat: true,
     canFormatDocument: false,
   }),
@@ -99,6 +106,12 @@ interface LanguageOptions {
    * created for non-diagnostic actions.
    */
   inject?: string[];
+  /**
+   * Comment out IPython magics (`%`, `%%`) and shell escapes (`!`) in the
+   * virtual document so they don't produce spurious diagnostics from language
+   * servers. Applies to IPython-flavored languages such as Python.
+   */
+  commentMagics?: boolean;
   canFormat?: boolean;
   canFormatDocument?: boolean;
 }
@@ -129,6 +142,7 @@ function defineLanguage(
     emptyLine: options?.emptyLine,
     trigger: language.trigger,
     inject: options?.inject,
+    commentMagics: options?.commentMagics,
     canFormat: options?.canFormat,
     canFormatDocument: options?.canFormatDocument
   };

--- a/apps/vscode/src/vdoc/vdoc.ts
+++ b/apps/vscode/src/vdoc/vdoc.ts
@@ -79,7 +79,7 @@ export async function virtualDoc(
 
 function virtualDocForBlock(document: TextDocument, block: Token, language: EmbeddedLanguage) {
   const lines = linesForLanguage(document, language);
-  fillLinesFromBlock(lines, document, block);
+  fillLinesFromBlock(lines, document, block, language);
   padLinesForLanguage(lines, language);
   return virtualDocForCode(lines, language);
 }
@@ -92,11 +92,17 @@ export function virtualDocForLanguage(
 ): VirtualDoc {
   const lines = linesForLanguage(document, language);
   for (const languageBlock of tokens.filter(isBlockOfLanguage(language))) {
-    fillLinesFromBlock(lines, document, languageBlock);
+    fillLinesFromBlock(lines, document, languageBlock, language);
   }
   padLinesForLanguage(lines, language);
   return virtualDocForCode(lines, language, action);
 }
+
+// IPython line magics (`%`), cell magics (`%%`), and shell escapes (`!`) are not
+// valid Python, so they produce spurious diagnostics from Python language
+// servers. Comment these lines out in the virtual document, mirroring how
+// Jupyter tooling (e.g. the ruff_notebook crate) sanitizes notebook input.
+const kIPythonMagicPattern = /^\s*(%{1,2}|!)/;
 
 function linesForLanguage(document: TextDocument, language: EmbeddedLanguage) {
   const lines: string[] = [];
@@ -106,13 +112,23 @@ function linesForLanguage(document: TextDocument, language: EmbeddedLanguage) {
   return lines;
 }
 
-function fillLinesFromBlock(lines: string[], document: TextDocument, block: Token) {
+function fillLinesFromBlock(
+  lines: string[],
+  document: TextDocument,
+  block: Token,
+  language: EmbeddedLanguage
+) {
   for (
     let line = block.range.start.line + 1;
     line < block.range.end.line && line < document.lineCount;
     line++
   ) {
-    lines[line] = document.lineAt(line).text;
+    const text = document.lineAt(line).text;
+    if (language.commentMagics && kIPythonMagicPattern.test(text)) {
+      lines[line] = language.emptyLine || "";
+    } else {
+      lines[line] = text;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1011

IPython magic lines (`%`, `%%`) and shell escapes (`!`) inside Python code cells are not valid Python, so third-party language servers like Pyrefly and Ruff flag them with spurious diagnostics:

<img width="688" height="403" alt="Screenshot 2026-06-16 at 10 59 08 AM" src="https://github.com/user-attachments/assets/18100424-d50b-44ba-8dee-383a7db44497" />

This does not happen in Jupyter notebooks, because tooling such as the `ruff_notebook` crate sanitizes notebook input first by commenting out these lines.

## Change in this PR

When Quarto builds the Python virtual document that gets fed to embedded language servers, magic and shell-escape lines are now replaced in place with the comment character (`#`) instead of being copied verbatim. This mirrors the existing mechanism that already blanks out non-code lines:

<img width="726" height="437" alt="Screenshot 2026-06-16 at 10 59 26 AM" src="https://github.com/user-attachments/assets/ac294eee-4240-401e-8e84-ace09c9ba758" />

Because the lines are substituted (not removed), line counts stay identical and all the existing position-mapping logic (`adjustedLine` / `unadjustedLine`) keeps working unchanged.

Details:

- Added a `commentMagics` language option, enabled for Python only since these are IPython/Jupyter specific.
- The pattern `/^\s*(%{1,2}|!)/` (from the issue) matches line magics, cell magics, and shell escapes, including leading whitespace.
- Unlike the existing `inject` directives (`# type: ignore`, `# flake8: noqa`), this applies to the `diagnostics` action too, which is the path the false diagnostics come through.
- Added an example (`vdoc/magics.qmd`) exercising `%`, `%%`, `!`, an indented `%time`, and surrounding real Python, plus a snapshot test confirming the magic lines become `#` while real Python is preserved.
- The cell magics (`%%bash`, etc.) only comment out the magic line itself, not the rest of the cell body. This matches the issue's suggested regex and keeps the change simple; full cell-magic handling can be a follow-up if users report it.
