### PR TITLE
Be more discriminating in failure popups

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.135.0 (Unreleased)
 
+- In Positron, running a cell that raises an error no longer results in an error toast message (<https://github.com/posit-dev/positron/issues/9845>).
+
 ## 1.134.0 (Release on 2026-06-22)
 
 - The "Preview" and "Preview Format..." commands now show in the Positron Notebook Editor overflow menu (<https://github.com/quarto-dev/quarto/pull/1001>).

--- a/apps/vscode/src/host/index.ts
+++ b/apps/vscode/src/host/index.ts
@@ -99,9 +99,9 @@ export interface ExtensionHost {
 
 }
 
-export function extensionHost(): ExtensionHost {
+export function extensionHost(outputChannel?: vscode.LogOutputChannel): ExtensionHost {
   if (tryAcquirePositronApi()) {
-    return positronExtensionHost();
+    return positronExtensionHost(outputChannel);
   } else {
     return defaultExtensionHost();
   }

--- a/apps/vscode/src/host/positron.ts
+++ b/apps/vscode/src/host/positron.ts
@@ -37,7 +37,7 @@ export function isInlineOutputEnabled(): boolean {
     .get<boolean>("enabled", false);
 }
 
-export function positronExtensionHost(): ExtensionHost {
+export function positronExtensionHost(outputChannel?: vscode.LogOutputChannel): ExtensionHost {
   return {
     // supported executable languages (we delegate to the default for langugaes
     // w/o runtimes so we support all languages)
@@ -68,18 +68,52 @@ export function positronExtensionHost(): ExtensionHost {
               const callback = async () => {
                 for (let i = 0; i < blocks.length; i++) {
                   const metadata = executionMetadata?.[i];
-                  await runtime.executeCode(
-                    language,   // The language ID
-                    blocks[i],  // The code string to execute
-                    false,      // Whether to focus the console
-                    true,       // Whether to allow incomplete code to run
-                    undefined,  // The execution mode
-                    undefined,  // The error behavior
-                    undefined,  // An optional observer
-                    undefined,  // The specific session ID in which to execute
-                    editorUri,  // The document URI
-                    metadata
-                  );
+
+                  // Track whether the runtime itself reported the failure. A
+                  // failure of the running code (a runtime error or syntax
+                  // error in the cell), an interrupt, or the session exiting are
+                  // all delivered through the execution observer's `onFailed`
+                  // callback before `executeCode` rejects. These are already
+                  // surfaced in the console, so we don't want to surface them
+                  // again. A rejection *without* `onFailed` having fired means
+                  // the code couldn't be submitted to the runtime at all (e.g.
+                  // no runtime is registered for the language), which is a
+                  // genuine problem worth reporting.
+                  let runtimeFailure = false;
+
+                  try {
+                    await runtime.executeCode(
+                      language,   // The language ID
+                      blocks[i],  // The code string to execute
+                      false,      // Whether to focus the console
+                      true,       // Whether to allow incomplete code to run
+                      undefined,  // The execution mode
+                      undefined,  // The error behavior
+                      { onFailed: () => { runtimeFailure = true; } }, // An execution observer
+                      undefined,  // The specific session ID in which to execute
+                      editorUri,  // The document URI
+                      metadata
+                    );
+                  } catch (err) {
+                    const message = err instanceof Error ? err.message : JSON.stringify(err);
+
+                    if (!runtimeFailure) {
+                      // The code couldn't be submitted to the runtime. Log it
+                      // and let it propagate so the user finds out.
+                      outputChannel?.error(`Failed to execute ${language} cell: ${message}`);
+                      throw err;
+                    }
+
+                    // The executed code raised an error (or was interrupted).
+                    // It's already reported in the console, so log it for the
+                    // record but don't let it propagate to the command handler,
+                    // which would surface it again as a notification popup.
+                    // https://github.com/posit-dev/positron/issues/9845
+                    outputChannel?.debug(`Error executing ${language} cell: ${message}`);
+
+                    // Stop executing any subsequent blocks since one failed.
+                    break;
+                  }
                 }
               };
 

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -67,7 +67,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Quarto
   outputChannel.info("Activating Quarto extension.");
 
   // create extension host
-  const host = extensionHost();
+  const host = extensionHost(outputChannel);
 
   // create markdown engine
   const engine = new MarkdownEngine();


### PR DESCRIPTION
This change prevents superfluous error notifications/toasts when running cells in Positron. 

The issue was that we were not catching exceptions thrown by `executeCode`. It is appropriate for exceptions to propagate here when we can't execute the code for some structural reason, but most often the failure is caused by the code itself.

When a cell fails to execute (a runtime/syntax error, an interrupt, or the session exiting) Positron already reports it in the console. Previously the rejection from `executeCode` also propagated up to the command handler, which surfaced it a second time as a notification popup.

This change distinguishes the two failure modes via the execution observer's `onFailed` callback:

- **Runtime-reported failures** (the code ran and errored): logged at debug level and swallowed so they aren't shown twice. Subsequent blocks are skipped since one failed.
- **Submission failures** (e.g. no runtime registered for the language): logged as an error and re-thrown so the user is notified, since these aren't otherwise surfaced.

Fixes posit-dev/positron#9845
