### PR TITLE
Hide the editor Preview button when Positron provides a native preview split button

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -728,7 +728,7 @@
       "editor/title/run": [
         {
           "command": "quarto.preview",
-          "when": "editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor'"
+          "when": "(editorLangId == quarto || editorLangId == markdown || activeCustomEditorId == 'quarto.visualEditor') && !quartoCanUsePositronPreviewSplitButton"
         },
         {
           "command": "quarto.previewScript",

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -15,6 +15,7 @@
 
 import * as vscode from "vscode";
 import debounce from "lodash.debounce";
+import { tryAcquirePositronApi } from "@posit-dev/positron";
 
 import { isQuartoDoc } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
@@ -43,6 +44,9 @@ export function activateContextKeySetter(
   // set the initial context keys
   setEditorContextKeys(vscode.window.activeTextEditor, engine);
   setLanguageContextKeys(vscode.window.activeTextEditor, engine);
+
+  // set the Positron preview split-button context key (static for the session)
+  setPositronPreviewSplitButtonContextKey();
 
   // register for quarto.render.renderOnSave or quarto.render.renderOnSaveShiny configuration change notification
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
@@ -116,6 +120,28 @@ export function toggleRenderOnSaveOverride() {
     renderOnSaveShinyOverride = !renderOnSaveShinyOverride;
     vscode.commands.executeCommand<boolean>('setContext', 'quarto.editor.renderOnSaveShiny', renderOnSaveShinyOverride);
   }
+}
+
+// Positron 2026.07.0+ provides a native Preview split button on the editor
+// action bar, with per-format preview in its dropdown. When running in such a
+// Positron, this context key lets us hide the extension's own `editor/title/run`
+// Preview button so there is a single button. Gating on the version (rather than
+// a Positron-set feature flag) keeps this temporal logic in the extension; the
+// check and key can be deleted once the supported Positron floor reaches that
+// version.
+//
+// String comparison, not `semver`: calendar versions like "2026.07.0" aren't
+// valid semver (leading zero in the month), but the zero-padded year/month sort
+// correctly lexicographically. This mirrors src/host/positron.ts.
+function setPositronPreviewSplitButtonContextKey() {
+  const positronVersion = tryAcquirePositronApi()?.version;
+  const canUsePositronPreviewSplitButton =
+    positronVersion !== undefined && positronVersion >= "2026.07.0";
+  vscode.commands.executeCommand(
+    "setContext",
+    "quartoCanUsePositronPreviewSplitButton",
+    canUsePositronPreviewSplitButton
+  );
 }
 
 // sets editor context keys


### PR DESCRIPTION
Positron 2026.07.0 is adding a native "Preview" split button to the editor action bar for Quarto documents as outlined in https://github.com/posit-dev/positron/issues/12891: a "Preview" primary action plus a dropdown to preview specific formats. This extension also contributes its own Preview button to `editor/title/run`, so in Positron both buttons would appear. The change in this PR hides the extension's button when Positron provides the native one, leaving a single Preview button.

It is a no-op in VS Code and in older Positron versions.

## How

- Adds a `quartoCanUsePositronPreviewSplitButton` context key, set once at activation in `context-keys.ts` when `positron.version >= "2026.07.0"`.
- Gates the `editor/title/run` `quarto.preview` contribution on `&& !quartoCanUsePositronPreviewSplitButton`.

The version check uses lexicographic string comparison rather than `semver`, matching the existing approach in `host/positron.ts`; Positron's zero-padded calendar versions such as `2026.07.0` are not valid semver, but the zero-padded year/month sort correctly as strings.

## Why a version gate rather than "is Positron"

The extension auto-updates from the marketplace independently of the Positron build, so a plain "hide whenever running in Positron" check would remove the button for users on older Positron versions that have no replacement button. Gating on the version means the button is hidden only once a Positron that actually provides the native split button is running. If that Positron release happens to slip past 2026.07.0 (which I assure you it WILL NOT 😉), the gate is a one-line follow-up.

## No behavior change elsewhere

- VS Code: no Positron API, the key is never set, the button shows as before.
- Positron < 2026.07.0: the key is not set, the button shows as before.

## Testing

- VS Code: Preview button still appears for `.qmd` / `.md` / the visual editor.
- Positron >= 2026.07.0: the extension's Preview button is hidden (Positron's native split button appears instead).
- Positron < 2026.07.0: the extension's Preview button still appears.
