### PR TITLE
Fix notebook markdown soft line breaks

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - In Positron, running a cell that raises an error no longer results in an error toast message (<https://github.com/posit-dev/positron/issues/9845>).
 - In Positron, Julia code cells in `.qmd` files can now be executed when the `ntluong95.positron-julia` extension is installed, the same way Python and R do (<https://github.com/quarto-dev/quarto/pull/989>).
+- Fixed a bug where soft line breaks within a paragraph were rendered as separate paragraphs in the markdown preview (<https://github.com/quarto-dev/quarto/pull/1027>).
 
 ## 1.134.0 (Release on 2026-06-22)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,10 @@
   },
   "devDependencies": {
     "@types/markdown-it": "^12.2.3",
-    "@types/markdown-it-attrs": "^4.1.0"
+    "@types/markdown-it-attrs": "^4.1.0",
+    "tsx": "^4.7.1"
+  },
+  "scripts": {
+    "test": "node --import tsx --test test/*.test.ts"
   }
 }

--- a/packages/core/src/markdownit/divs.ts
+++ b/packages/core/src/markdownit/divs.ts
@@ -38,11 +38,6 @@ export const divPlugin = (md: MarkdownIt) => {
     kDivRuleName,
     (state, start, _end, silent) => {
 
-      // This is a validation run, can ignore
-      if (silent) {
-        return true;
-      }
-      
       // Get the line for parsing
       const lineStart = state.bMarks[start] + state.tShift[start];
       const lineEnd = state.eMarks[start];
@@ -85,6 +80,12 @@ export const divPlugin = (md: MarkdownIt) => {
       }
 
       if (match) {
+        // This is a validation run. Report that actual div markers interrupt
+        // paragraphs, but avoid mutating div state until the parser consumes it.
+        if (silent) {
+          return true;
+        }
+
         // There is a div here, is one already open?
         const divFence = match[1];
         const attr = match[2];

--- a/packages/core/test/markdownit-divs.test.ts
+++ b/packages/core/test/markdownit-divs.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import MarkdownIt from "markdown-it";
+import { divPlugin } from "../src/markdownit/divs";
+
+const render = (src: string) => {
+  const md = new MarkdownIt({ html: true });
+  md.use(divPlugin);
+  return md.render(src);
+};
+
+test("pandoc divs do not turn soft line breaks into paragraph breaks", () => {
+  assert.equal(render("Hello\nworld"), "<p>Hello\nworld</p>\n");
+});
+
+test("pandoc div markers still interrupt paragraphs", () => {
+  assert.equal(
+    render("Before\n:::\nInside\n:::"),
+    "<p>Before</p>\n<div  class=\"quarto-div\"><p>Inside</p>\n</div>"
+  );
+});


### PR DESCRIPTION
Markdown cells in notebooks were rendering soft line breaks as hard paragraph breaks when the Quarto Markdown-It renderer was active. The Pandoc div rule reported every line as a paragraph interrupter during Markdown-It silent validation, so hard-wrapped prose was split before normal Markdown rendering could preserve soft break semantics.

This updates the div parser so silent validation only reports an interruption for actual `:::` div markers and does not mutate parser state until the marker is consumed. The new core tests cover both the soft-break regression and the expected paragraph interruption for Pandoc div markers.

Fixes quarto-dev/quarto#1017

Tests:
- `npx --yes yarn@1.22.22 workspace core test`
- `npx --yes yarn@1.22.22 workspace quarto-vscode-markdownit build`
- `npx --yes yarn@1.22.22 build-vscode`