### PR TITLE
Patch linkify-it ReDoS (SNYK-JS-LINKIFYIT-17817062)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "watch": "concurrently 'tsc --watch --noEmit --project apps/writer/tsconfig.json' 'tsc --watch --noEmit  --project packages/writer-server/tsconfig.json'"
   },
+  "resolutions": {
+    "linkify-it": "5.0.2"
+  },
   "devDependencies": {
     "@vscode/test-cli": "^0.0.11",
     "concurrently": "^7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6594,19 +6594,12 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@5.0.2, linkify-it@^3.0.1, linkify-it@^4.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
-    uc.micro "^1.0.1"
-
-linkify-it@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz"
-  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
-  dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 listenercount@~1.0.1:
   version "1.0.1"
@@ -9464,10 +9457,15 @@ typo-js@^1.2.2:
   resolved "https://registry.npmjs.org/typo-js/-/typo-js-1.2.2.tgz"
   integrity sha512-C7pYBQK17EjSg8tVNY91KHdUt5Nf6FMJ+c3js076quPmBML57PmNMzAcIq/2kf/hSYtFABNDIYNYlJRl5BJhGw==
 
-uc.micro@^1.0.1, uc.micro@^1.0.5:
+uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uc.micro@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Force the transitive linkify-it dependency to the patched 5.0.2 via a root resolutions entry, closing the ReDoS advisory (CVE-2026-48801) across all dependency paths (markdown-it in core, quarto-core, editor-codemirror, vscode, and vscode-markdownit, plus the markdown-it bundled in the vsce packaging tool).

This supersedes the Snyk PRs (#1038, #1039, #1040, #1041, #1042), each of which proposed a major-version bump of markdown-it (12/13 to 14) to shift a single path off the vulnerable package. Unlike brace-expansion, linkify-it has no patched 3.x or 4.x release, so the fix requires linkify-it 5; the resolutions override reaches every path at once with no markdown-it 14 migration (no `@types` bump, no .mjs deep-import rewrites) and no behavior change, since linkify-it's public API is unchanged across v3 to v5.

- Closes #1038
- Closes #1039
- Closes #1040
- Closes #1041
- Closes #1042
