### PR TITLE
Bump version and changelog

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.136.0 (Unreleased)
+
 ## 1.135.0 (Release on 2026-07-08)
 
 - In Positron, running a cell that raises an error no longer results in an error toast message (<https://github.com/posit-dev/positron/issues/9845>).

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -11,7 +11,7 @@
     "pandoc",
     "quarto"
   ],
-  "version": "1.135.0",
+  "version": "1.136.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode"


### PR DESCRIPTION
Bump to the next version of the extension, 1.136