### PR TITLE
fix(logo): use correct Quarto logo colour `#74AADB`

### DIFF
--- a/apps/vscode/assets/icon/qmd.svg
+++ b/apps/vscode/assets/icon/qmd.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#4E97B4;}
+	.st0{fill:#74AADB;}
 </style>
 <g>
 	<path class="st0" d="M8.34,7.65h5.16c-0.17-2.77-2.39-4.99-5.16-5.15V7.65z"/>


### PR DESCRIPTION
Update the Quarto logo colour to the correct shade for consistency and branding.

- https://github.com/orgs/quarto-dev/discussions/14672

Closes https://github.com/posit-dev/positron/issues/14831

---

Source: [quarto.org icon logo](https://github.com/quarto-dev/quarto-web/blob/main/quarto-icon.svg) and the update PNG trademark version is being added with:

- https://github.com/quarto-dev/quarto-web/pull/2099