### PR TITLE
Patch js-yaml merge-key DoS (SNYK-JS-JSYAML-17900054)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6440,7 +6440,7 @@ js-sdsl@^4.1.4:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
+js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -6448,12 +6448,19 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
     argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  version "3.15.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  dependencies:
+    argparse "^2.0.1"
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"


### PR DESCRIPTION
Re-resolve the transitive js-yaml dependency to patched versions within each major line (4.3.0 for the `^4.1.0` consumers, 3.15.0 for eslint's transitive `^3.13.1`), closing the quadratic-complexity merge-key DoS advisory (SNYK-JS-JSYAML-17900054 / CVE-2026-53550) across all dependency paths. The same bump also clears the related prototype-pollution-in-merge advisory (CVE-2025-64718, fixed in 3.14.2 and 4.1.1) on those same paths.

This supersedes the Snyk PRs #1048, #1049, #1050, #1051, and #1054, each of which proposed bumping js-yaml to 4.3.0 in a single package.json (quarto-core, editor-server, lsp, vscode, and vscode-markdownit), and #1053, which proposed bumping eslint from 7 to 9 in quarto-ojs-runtime solely to drag its transitive js-yaml 3.x off the vulnerable version. The lockfile re-resolution fixes every path at once, including the transitive js-yaml 3.x pulled in by eslint, with no package.json changes and no eslint 9 flat-config migration. js-yaml's public API is unchanged across these patch/minor bumps (both the 3.x and 4.x lines keep the same `load`/`dump` API and the same `argparse`/`esprima` deps), so there is no behavior change.

One dev-only copy of js-yaml 4.1.0 remains, pinned exactly by mocha 9's test runner; it is not reachable by lockfile re-resolution and only ever parses trusted local config, so it is left as-is.

- Closes #1048
- Closes #1049
- Closes #1050
- Closes #1051
- Closes #1053
- Closes #1054

This PR addresses part of #1052 but not all of that one; I think we'll handle that separately.