### PR TITLE
Lazy start Quarto LSP to reduce memory usage in non-Quarto workspaces

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.136.0 (Unreleased)
 
+- Reduce memory usage by only starting the language server (LSP) in projects containing Quarto documents (https://github.com/quarto-dev/quarto/pull/1059)
+
 ## 1.135.0 (Release on 2026-07-08)
 
 - In Positron, running a cell that raises an error no longer results in an error toast message (<https://github.com/posit-dev/positron/issues/9845>).

--- a/apps/vscode/src/lsp/client.ts
+++ b/apps/vscode/src/lsp/client.ts
@@ -29,6 +29,8 @@ import {
   DocumentSymbol,
   Range,
   SymbolKind,
+  Disposable,
+  languages,
 } from "vscode";
 import {
   LanguageClient,
@@ -72,19 +74,59 @@ import { embeddedSemanticTokensProvider } from "../providers/semantic-tokens";
 import { getHover, getSignatureHelpHover } from "../core/hover";
 import { imageHover } from "../providers/hover-image";
 import { LspInitializationOptions, QuartoContext } from "quarto-core";
+import { lspClientTransport } from "core-node";
+import { JsonRpcRequestTransport } from "core";
 import { extensionHost } from "../host";
 import semver from "semver";
 import { EmbeddedLanguage } from "../vdoc/languages";
 import { SymbolInformation } from "vscode";
 
-let client: LanguageClient;
+// The active language client. Retained at module scope so `deactivate` can stop
+// it. It is created eagerly during activation but the underlying server process
+// is not spawned until the client is actually needed (see `ensureStarted`).
+let client: LanguageClient | undefined;
 
-export async function activateLsp(
+/**
+ * Handle returned by {@link activateLsp}. It lets consumers talk to the Quarto
+ * language server without forcing it to start at extension activation. The
+ * server process (~100MB) is spawned lazily the first time it is actually
+ * needed: when a document it serves is opened, or when a request is issued
+ * through {@link QuartoLspClient.lspRequest}.
+ */
+export interface QuartoLspClient {
+  /**
+   * JSON-RPC transport that lazily starts the language server on first use and
+   * waits for it to be running before issuing the request.
+   */
+  lspRequest: JsonRpcRequestTransport;
+
+  /**
+   * Register a callback invoked each time the server reaches the running state.
+   * Registering does NOT itself start the server; use this for work that should
+   * happen "if and when" the server comes up (e.g. pushing configuration). If
+   * the server is already running the callback is invoked immediately.
+   */
+  onReady: (callback: (client: LanguageClient) => void) => Disposable;
+
+  /**
+   * Start the language server if it has not already been started. Idempotent:
+   * repeated calls return the same promise.
+   */
+  ensureStarted: () => Promise<LanguageClient>;
+
+  /**
+   * The underlying language client if it is currently running, otherwise
+   * undefined. Useful for "fire only if already running" behavior.
+   */
+  runningClient: () => LanguageClient | undefined;
+}
+
+export function activateLsp(
   context: ExtensionContext,
   quartoContext: QuartoContext,
   engine: MarkdownEngine,
   outputChannel: LogOutputChannel,
-) {
+): QuartoLspClient {
 
   // The server is implemented in node
   const serverModule = context.asAbsolutePath(
@@ -137,64 +179,147 @@ export async function activateLsp(
     "**/_{brand,quarto,metadata,extension}*.{yml,yaml}" :
     "**/_{quarto,metadata,extension}*.{yml,yaml}";
 
+  // documents this server handles; also used to decide when to lazily start it
+  const documentSelector = [
+    { scheme: "*", language: "quarto" },
+    {
+      scheme: "*",
+      language: "yaml",
+      pattern: documentSelectorPattern,
+    },
+  ];
+
   const clientOptions: LanguageClientOptions = {
     initializationOptions,
-    documentSelector: [
-      { scheme: "*", language: "quarto" },
-      {
-        scheme: "*",
-        language: "yaml",
-        pattern: documentSelectorPattern,
-      },
-    ],
+    documentSelector,
     middleware,
     outputChannel
   };
 
-  // Create the language client and start the client.
-  client = new LanguageClient(
+  // Create the language client. NOTE: we deliberately do NOT start it here;
+  // startup is deferred until the server is actually needed (see below).
+  const languageClient = new LanguageClient(
     "quarto-lsp",
     "Quarto LSP",
     serverOptions,
     clientOptions
   );
+  client = languageClient;
 
-  // Helper to send current theme to LSP server
+  // callbacks to invoke each time the server reaches the running state
+  const readyCallbacks = new Set<(client: LanguageClient) => void>();
+  const onReady = (callback: (client: LanguageClient) => void): Disposable => {
+    readyCallbacks.add(callback);
+    // if the server is already running, invoke immediately
+    if (languageClient.state === State.Running) {
+      callback(languageClient);
+    }
+    return new Disposable(() => {
+      readyCallbacks.delete(callback);
+    });
+  };
+
+  // Helper to send current theme to LSP server (no-op unless it is running)
   const sendThemeNotification = () => {
-    if (client) {
+    if (languageClient.state === State.Running) {
       const kind = (window.activeColorTheme.kind === ColorThemeKind.Light || window.activeColorTheme.kind === ColorThemeKind.HighContrastLight) ? "light" : "dark";
-      client.sendNotification("quarto/didChangeActiveColorTheme", { kind });
+      languageClient.sendNotification("quarto/didChangeActiveColorTheme", { kind });
     }
   };
 
-  // Listen for theme changes and notify the server
+  // Send the computed theme whenever the server starts, and on theme changes
+  onReady(() => sendThemeNotification());
   context.subscriptions.push(
     window.onDidChangeActiveColorTheme(() => {
       sendThemeNotification();
     })
   );
 
-  // return once the server is running
-  return new Promise<LanguageClient>((resolve, reject) => {
+  // Start the server on first use. Idempotent: the promise is memoized so
+  // repeated calls (and multiple triggers) only launch the server once.
+  let startPromise: Promise<LanguageClient> | undefined;
+  const ensureStarted = (): Promise<LanguageClient> => {
+    if (!startPromise) {
+      outputChannel.info("Starting Quarto LSP server.");
+      startPromise = new Promise<LanguageClient>((resolve, reject) => {
+        const handler = languageClient.onDidChangeState(e => {
+          if (e.newState === State.Running) {
+            handler.dispose();
+            // notify readiness listeners (theme, zotero config, ...)
+            readyCallbacks.forEach(cb => cb(languageClient));
+            resolve(languageClient);
+          } else if (e.newState === State.Stopped) {
+            handler.dispose();
+            reject(new Error("Failed to start Quarto LSP Server"));
+          }
+        });
+        // Start the client. This will also launch the server.
+        languageClient.start();
+      });
+    }
+    return startPromise;
+  };
 
-    const handler = client.onDidChangeState(e => {
-      if (e.newState === State.Running) {
-        handler.dispose();
-        // Send computed theme on startup
-        sendThemeNotification();
-        resolve(client);
-      } else if (e.newState === State.Stopped) {
-        reject(new Error("Failed to start Quarto LSP Server"));
-      }
+  // Lazy JSON-RPC transport: starts the server on first use, then forwards.
+  let transport: JsonRpcRequestTransport | undefined;
+  const lspRequest: JsonRpcRequestTransport = async (method, params) => {
+    const started = await ensureStarted();
+    if (!transport) {
+      transport = lspClientTransport(started);
+    }
+    return transport(method, params);
+  };
+
+  const runningClient = () =>
+    languageClient.state === State.Running ? languageClient : undefined;
+
+  const startLazily = () => {
+    void ensureStarted().catch(() => {
+      // failure is reported to the output channel by the client itself
     });
+  };
 
-    // Start the client. This will also launch the server
-    client.start();
-  });
+  // Lazily start the server when a document it serves is opened. Check the
+  // documents already open at activation, then listen for newly opened ones.
+  const maybeStartForDocument = (doc: TextDocument) => {
+    if (languages.match(documentSelector, doc) > 0) {
+      startLazily();
+    }
+  };
+  workspace.textDocuments.forEach(maybeStartForDocument);
+  context.subscriptions.push(
+    workspace.onDidOpenTextDocument(maybeStartForDocument)
+  );
+
+  // Also start the server if the workspace already contains Quarto content, so
+  // that workspace-wide features (symbol search, cross-file navigation, project
+  // indexing) work before any document is opened. This keeps behavior identical
+  // to eager startup for real Quarto projects, while non-Quarto sessions (e.g.
+  // editing R files in a workspace with no Quarto files) never spawn the server.
+  if (workspace.workspaceFolders?.length) {
+    const contentGlobs = ["**/*.{qmd,rmd}", documentSelectorPattern];
+    void (async () => {
+      for (const glob of contentGlobs) {
+        // stop early if some other trigger (e.g. an open document) already started it
+        if (startPromise) {
+          return;
+        }
+        const found = await workspace.findFiles(glob, undefined, 1);
+        if (found.length > 0) {
+          startLazily();
+          return;
+        }
+      }
+    })();
+  }
+
+  return { lspRequest, onReady, ensureStarted, runningClient };
 }
 
 export function deactivate(): Thenable<void> | undefined {
-  if (!client) {
+  // Nothing to stop if the server was never started (state stays Stopped until
+  // the first `start()` call).
+  if (!client || client.state === State.Stopped) {
     return undefined;
   }
   return client.stop();

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -128,14 +128,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<Quarto
     embeddedDiagnosticsService = activateEmbeddedDiagnostics(engine, outputChannel);
     context.subscriptions.push(embeddedDiagnosticsService);
 
-    // lsp
-    const lspClient = await activateLsp(context, quartoContext, engine, outputChannel);
+    // lsp (started lazily on first use, not at activation)
+    const lspClient = activateLsp(context, quartoContext, engine, outputChannel);
 
     // restore outline expansion after the LSP re-registers symbols on config change
     registerOutlineConfigListener(context);
 
     // provide visual editor
-    const editorCommands = activateEditor(context, host, quartoContext, lspClient, engine);
+    const editorCommands = activateEditor(context, host, quartoContext, lspClient.lspRequest, engine);
     commands.push(...editorCommands);
 
     // zotero

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -38,8 +38,6 @@ import {
   TabInputText
 } from "vscode";
 
-import { LanguageClient } from "vscode-languageclient/node";
-
 import { projectDirForDocument, QuartoContext } from "quarto-core";
 
 import { CodeViewActiveBlockContext, CodeViewSelectionAction, HostContext, NavLocation, Prefs, SourcePos, VSCodeVisualEditor, VSCodeVisualEditorHost, XRef } from "editor-types";
@@ -56,7 +54,6 @@ import { clearInterval } from "timers";
 import { vscodePrefsServer } from "./prefs";
 import { vscodeCodeViewServer } from "./codeview";
 import { MarkdownEngine } from "../../markdown/engine";
-import { lspClientTransport } from "core-node";
 import { editorSourceJsonRpcServer } from "editor-core";
 import { JsonRpcRequestTransport } from "core";
 import {
@@ -80,11 +77,11 @@ export function activateEditor(
   context: ExtensionContext,
   host: ExtensionHost,
   quartoContext: QuartoContext,
-  lspClient: LanguageClient,
+  lspRequest: JsonRpcRequestTransport,
   engine: MarkdownEngine
 ): Command[] {
   // register the provider
-  context.subscriptions.push(VisualEditorProvider.register(context, host, quartoContext, lspClient, engine));
+  context.subscriptions.push(VisualEditorProvider.register(context, host, quartoContext, lspRequest, engine));
 
   // return commands
   return [
@@ -135,12 +132,9 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
     context: ExtensionContext,
     host: ExtensionHost,
     quartoContext: QuartoContext,
-    lspClient: LanguageClient,
+    lspRequest: JsonRpcRequestTransport,
     engine: MarkdownEngine
   ): Disposable {
-
-    // setup request transport
-    const lspRequest = lspClientTransport(lspClient);
 
     // track edits in the active editor if its untitled. this enables us to recover the
     // content when we switch to an untitled document, which otherwise are just dropped

--- a/apps/vscode/src/providers/zotero/zotero.ts
+++ b/apps/vscode/src/providers/zotero/zotero.ts
@@ -29,13 +29,22 @@ const kZoteroConfigureLibrary = "quarto.zoteroConfigureLibrary";
 const kZoteroSyncWebLibrary = "quarto.zoteroSyncWebLibrary";
 const kZoteroUnauthorized = "quarto.zoteroUnauthorized";
 
+// Resolves once the initial Zotero library configuration has been pushed to the
+// (lazily started) LSP server. Zotero data requests await this so that the
+// backend knows which library is configured before it answers; otherwise, with
+// lazy startup, a request that triggered startup could reach the server before
+// `setLibraryConfig` and get back empty results. Assigned by `activateZotero`;
+// defaults to a no-op so `zoteroLspProxy` is safe if Zotero was never activated.
+let ensureZoteroConfigSynced: () => Promise<void> = () => Promise.resolve();
+
 export async function activateZotero(context: ExtensionContext, lsp: QuartoLspClient): Promise<Command[]> {
 
   // establish zotero connection (lazy: does not force the LSP to start)
   const zotero = editorZoteroJsonRpcServer(lsp.lspRequest);
 
-  // sync quarto config to the back end (whenever the LSP server is running)
-  syncZoteroConfig(context, zotero, lsp);
+  // sync quarto config to the back end (whenever the LSP server is running);
+  // exposes the gate that Zotero data requests await before running
+  ensureZoteroConfigSynced = syncZoteroConfig(context, zotero, lsp);
 
   // register commands
   const commands: Command[] = [];
@@ -48,7 +57,7 @@ export async function activateZotero(context: ExtensionContext, lsp: QuartoLspCl
 }
 
 
-function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer, lsp: QuartoLspClient) {
+function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer, lsp: QuartoLspClient): () => Promise<void> {
 
   const kZoteroConfig = "quarto.zotero";
   const kLibrary = "library";
@@ -76,11 +85,28 @@ function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer, lsp: 
     }
   };
 
-  // push config whenever the LSP server starts (this both handles the initial
-  // sync and re-syncs after any config change made while the server was down).
-  // We deliberately do NOT start the server just to push config; if it isn't
-  // running the config will be picked up the next time it starts.
-  context.subscriptions.push(lsp.onReady(() => { void pushLibraryConfig(); }));
+  // Ensure the initial library config has been pushed to a running server.
+  // Memoized so the many potential callers (server startup, and every Zotero
+  // data request) only trigger a single push. It starts the server if needed,
+  // which is also what prevents a deadlock: a Zotero data request that awaits
+  // this gate before it ever hits the transport would otherwise wait forever
+  // for a config sync that never happens because nothing started the server.
+  // Note `pushLibraryConfig` uses the ungated `zotero` connection, so its own
+  // `setLibraryConfig` call does not wait on this gate.
+  let configSyncPromise: Promise<void> | undefined;
+  const ensureLibraryConfigSynced = (): Promise<void> => {
+    if (!configSyncPromise) {
+      configSyncPromise = (async () => {
+        await lsp.ensureStarted();
+        await pushLibraryConfig();
+      })();
+    }
+    return configSyncPromise;
+  };
+
+  // push config as soon as the server starts, so citation completion is ready
+  // without waiting for the first Zotero request (matches prior eager behavior)
+  context.subscriptions.push(lsp.onReady(() => { void ensureLibraryConfigSynced(); }));
 
   // push config on change, but only if the server is already running
   const pushLibraryConfigIfRunning = async () => {
@@ -136,6 +162,8 @@ function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer, lsp: 
       groupLibraries = updatedGroupLibraries;
     }
   }));
+
+  return ensureLibraryConfigSynced;
 }
 
 // proxy for zotero requests that:
@@ -143,7 +171,17 @@ function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer, lsp: 
 // (b) checks for unauthorized errors and prompts for re-authorization
 export function zoteroLspProxy(lspRequest: JsonRpcRequestTransport) {
 
-  const zoteroLsp = editorZoteroJsonRpcServer(lspRequest);
+  // Gate Zotero requests on the initial library-config sync so the backend
+  // knows the configured library before answering. Without this, the lazily
+  // started LSP could receive a data request (which itself triggered startup)
+  // before `setLibraryConfig`, returning empty results. The gate also starts
+  // the server if it isn't running yet, so a Zotero request can drive startup.
+  const gatedRequest: JsonRpcRequestTransport = async (method, params) => {
+    await ensureZoteroConfigSynced();
+    return lspRequest(method, params);
+  };
+
+  const zoteroLsp = editorZoteroJsonRpcServer(gatedRequest);
 
   const handleZoteroResult = (result: ZoteroResult) => {
     if (result.status === 'notfound' && result.unauthorized) {

--- a/apps/vscode/src/providers/zotero/zotero.ts
+++ b/apps/vscode/src/providers/zotero/zotero.ts
@@ -17,12 +17,11 @@ import { ExtensionContext, ProgressLocation, commands, window, workspace, Uri } 
 import { zoteroApi, zoteroSyncWebLibraries, zoteroValidateApiKey } from "editor-server";
 
 import { Command } from "../../core/command";
-import { LanguageClient } from "vscode-languageclient/node";
-import { lspClientTransport } from "core-node";
+import { QuartoLspClient } from "../../lsp/client";
 import { editorZoteroJsonRpcServer } from "editor-core";
 import { ZoteroCollectionSpec, ZoteroResult, ZoteroServer, kZoteroMyLibrary } from "editor-types";
 import { zoteroServerMethods } from "editor-server/src/server/zotero";
-import { JsonRpcRequestTransport, sleep } from "core";
+import { JsonRpcRequestTransport } from "core";
 
 const kQuartoZoteroWebApiKey = "quartoZoteroWebApiKey";
 
@@ -30,14 +29,13 @@ const kZoteroConfigureLibrary = "quarto.zoteroConfigureLibrary";
 const kZoteroSyncWebLibrary = "quarto.zoteroSyncWebLibrary";
 const kZoteroUnauthorized = "quarto.zoteroUnauthorized";
 
-export async function activateZotero(context: ExtensionContext, lspClient: LanguageClient): Promise<Command[]> {
+export async function activateZotero(context: ExtensionContext, lsp: QuartoLspClient): Promise<Command[]> {
 
-  // establish zotero connection
-  const lspRequest = lspClientTransport(lspClient);
-  const zotero = editorZoteroJsonRpcServer(lspRequest);
+  // establish zotero connection (lazy: does not force the LSP to start)
+  const zotero = editorZoteroJsonRpcServer(lsp.lspRequest);
 
-  // set quarto config for back end
-  await syncZoteroConfig(context, zotero);
+  // sync quarto config to the back end (whenever the LSP server is running)
+  syncZoteroConfig(context, zotero, lsp);
 
   // register commands
   const commands: Command[] = [];
@@ -50,7 +48,7 @@ export async function activateZotero(context: ExtensionContext, lspClient: Langu
 }
 
 
-async function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer) {
+function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer, lsp: QuartoLspClient) {
 
   const kZoteroConfig = "quarto.zotero";
   const kLibrary = "library";
@@ -60,15 +58,8 @@ async function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer)
   const kGroupLibraries = "groupLibraries";
   const kZoteroGroupLibraries = `${kZoteroConfig}.${kGroupLibraries}`;
 
-  // set initial config
-  const setLspLibraryConfig = async (retry?: number) => {
-    // if this isn't a retry then provide an initial delay (for the lsp to be ready)
-    if (retry === undefined) {
-      await sleep(500);
-      // if this is our final retry then bail
-    } else if (retry === 5) {
-      return;
-    }
+  // push the current library config to the LSP server
+  const pushLibraryConfig = async () => {
     const zoteroConfig = workspace.getConfiguration(kZoteroConfig);
     const type = zoteroConfig.get<"none" | "local" | "web">(kLibrary, "local");
     const dataDir = zoteroConfig.get<string>(kDataDir, "");
@@ -82,10 +73,21 @@ async function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer)
     } catch (error) {
       const message = error instanceof Error ? error.message : JSON.stringify(error);
       console.log("Error setting zotero library config: " + message);
-      setTimeout(() => setLspLibraryConfig((retry || 0) + 1), 1000);
     }
   };
-  await setLspLibraryConfig();
+
+  // push config whenever the LSP server starts (this both handles the initial
+  // sync and re-syncs after any config change made while the server was down).
+  // We deliberately do NOT start the server just to push config; if it isn't
+  // running the config will be picked up the next time it starts.
+  context.subscriptions.push(lsp.onReady(() => { void pushLibraryConfig(); }));
+
+  // push config on change, but only if the server is already running
+  const pushLibraryConfigIfRunning = async () => {
+    if (lsp.runningClient()) {
+      await pushLibraryConfig();
+    }
+  };
 
   // note initial group library config (for detecting changes)
   const zoteroConfig = workspace.getConfiguration(kZoteroConfig);
@@ -94,7 +96,7 @@ async function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer)
   // monitor changes to web api key and update lsp
   context.secrets.onDidChange(async (e) => {
     if (e.key === kQuartoZoteroWebApiKey) {
-      await setLspLibraryConfig();
+      await pushLibraryConfigIfRunning();
     }
   });
 
@@ -111,7 +113,7 @@ async function syncZoteroConfig(context: ExtensionContext, zotero: ZoteroServer)
         !(await safeReadZoteroApiKey(context))) {
         await commands.executeCommand(kZoteroConfigureLibrary);
       } else {
-        await setLspLibraryConfig();
+        await pushLibraryConfigIfRunning();
       }
     }
 

--- a/apps/vscode/src/test/convert.test.ts
+++ b/apps/vscode/src/test/convert.test.ts
@@ -8,6 +8,11 @@ import {
 } from "./test-utils";
 
 suite("Convert Commands", function () {
+  // Each test spawns `quarto convert`; the first (cold) CLI spawn can exceed
+  // mocha's default 5s timeout, especially when the lazily-started LSP is
+  // warming up concurrently. Give the whole suite generous headroom.
+  this.timeout(30000);
+
   suiteSetup(async function () {
     await vscode.workspace.fs.delete(examplesOutUri(), { recursive: true });
     await vscode.workspace.fs.copy(

--- a/apps/vscode/src/test/r-project.test.ts
+++ b/apps/vscode/src/test/r-project.test.ts
@@ -1,10 +1,18 @@
 import * as vscode from "vscode";
 import * as assert from "assert";
+import { waitForWorkspaceSymbol } from "./test-utils";
 
 // This file is for testing behaviour that is specific to R projects, i.e.
 // projects with a top-level `DESCRIPTION` file.
 
 suite("Workspace Symbols - R Project", function () {
+  suiteSetup(async function () {
+    // The LSP now starts lazily, so wait for it to be running and have indexed
+    // the workspace before asserting on symbol results.
+    this.timeout(30000);
+    await waitForWorkspaceSymbol("Symbols-Header-1");
+  });
+
   teardown(async function () {
     await vscode.workspace
       .getConfiguration("quarto")

--- a/apps/vscode/src/test/symbols.test.ts
+++ b/apps/vscode/src/test/symbols.test.ts
@@ -1,9 +1,16 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import * as assert from "assert";
-import { WORKSPACE_PATH } from "./test-utils";
+import { WORKSPACE_PATH, waitForWorkspaceSymbol } from "./test-utils";
 
 suite("Workspace Symbols", function () {
+  suiteSetup(async function () {
+    // The LSP now starts lazily, so wait for it to be running and have indexed
+    // the workspace before asserting on symbol results.
+    this.timeout(30000);
+    await waitForWorkspaceSymbol("Symbols-Header-1");
+  });
+
   teardown(async function () {
     await vscode.workspace
       .getConfiguration("quarto")

--- a/apps/vscode/src/test/test-utils.ts
+++ b/apps/vscode/src/test/test-utils.ts
@@ -29,6 +29,49 @@ export function wait(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * Polls `condition` until it returns true or `timeout` elapses. Useful for
+ * waiting on asynchronous, eventually-consistent state such as the Quarto LSP
+ * finishing its (now lazy) startup and indexing before making assertions.
+ */
+export async function waitForCondition(
+  condition: () => boolean | Promise<boolean>,
+  { timeout = 15000, interval = 100, message = "condition" }: { timeout?: number; interval?: number; message?: string } = {}
+): Promise<void> {
+  const start = Date.now();
+  for (; ;) {
+    if (await condition()) {
+      return;
+    }
+    if (Date.now() - start >= timeout) {
+      throw new Error(`Timed out after ${timeout}ms waiting for ${message}`);
+    }
+    await wait(interval);
+  }
+}
+
+/**
+ * Waits until the (lazily started) Quarto LSP is running and has indexed the
+ * workspace, detected by the presence of a known workspace symbol. Sets
+ * `symbols.exportToWorkspace` to "all" so the probe symbol is visible
+ * regardless of project type (e.g. R projects filter symbols by default).
+ */
+export async function waitForWorkspaceSymbol(name: string) {
+  await vscode.workspace
+    .getConfiguration("quarto")
+    .update("symbols.exportToWorkspace", "all");
+  await waitForCondition(
+    async () => {
+      const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+        "vscode.executeWorkspaceSymbolProvider",
+        ""
+      );
+      return !!symbols?.find((s) => s.name === name);
+    },
+    { message: `Quarto LSP workspace symbol "${name}"` }
+  );
+}
+
 export async function openAndShowExamplesTextDocument(
   fileName: string,
   showOptions?: vscode.TextDocumentShowOptions


### PR DESCRIPTION
The Quarto language server is a separate Node process that consumes 50-100mb of RAM in every Positron session.

Until now it was launched the moment the extension activated, which meant every VS Code window paid that memory cost, including windows that never touch a Quarto document. The most common example is an R project (or any other workspace) that happens to have the Quarto extension installed but contains no `.qmd`/`.rmd` files at all. Those sessions were carrying ~98 MB of steady-state overhead for a server they would never use.

The goal of this change is to reduce steady-state memory usage, and especially to bring it to zero for workspaces that have no Quarto content.

### What changed

The language server is now started **lazily**, on first actual need, rather than eagerly at activation. Concretely, the extension still creates the language client during activation (so everything is wired up and ready), but it defers spawning the server process until one of the following happens:

- A document the server handles (a Quarto document, or a relevant YAML config file) is opened — this covers both documents already open when the window loads and any opened later.
- The workspace is found to already contain Quarto content, so that project-wide features like workspace symbol search and cross-file navigation still work before any file is opened.
- A feature issues a request to the server (for example the visual editor or Zotero integration).

If none of these ever occur, such as the "R project with no Quarto files" case, the server is never spawned and the ~98 MB is never allocated. For real Quarto projects, behavior is effectively unchanged; the server comes up as soon as it's needed.

### How it's wired up

Activation now returns a small handle instead of the raw language client. The handle exposes a lazy request transport, an `onReady` hook for work that should run "if and when" the server starts (used for pushing the color theme and Zotero configuration), an idempotent `ensureStarted`, and a way to ask for the client only if it's already running.

This let a couple of consumers get simpler and better-behaved:

- **Zotero config sync** no longer force-starts the server. It pushes configuration whenever the server becomes ready and re-pushes on config changes only if the server is already running. This also replaced the old fixed-delay/retry-with-`sleep` approach with a clean readiness callback.
- **The visual editor** now receives the lazy request transport directly rather than the language client.

`deactivate` was updated to be a no-op when the server was never started.

### Tests

Because the server no longer starts eagerly, the workspace-symbol tests could race against startup and indexing. Added a shared `waitForWorkspaceSymbol` helper (built on a general `waitForCondition` poller) and a `suiteSetup` in the affected suites that waits for the server to be running and to have indexed the workspace before asserting.
