### PR TITLE
friendlier error for DOIs without citation metadata

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.136.0 (Unreleased)
 
 - Reduce memory usage by only starting the language server (LSP) in projects containing Quarto documents (https://github.com/quarto-dev/quarto/pull/1059)
+- Improved the error message shown when inserting a citation from a DOI whose registration agency does not provide citation metadata (<https://github.com/quarto-dev/quarto/pull/1061>).
 
 ## 1.135.0 (Release on 2026-07-08)
 

--- a/packages/editor-server/src/server/doi.ts
+++ b/packages/editor-server/src/server/doi.ts
@@ -28,9 +28,21 @@ export function doiServer() : DOIServer {
   return {
     async fetchCSL(doi: string) : Promise<DOIResult> {
       const url = `${kDOIHost}/${doi}`;
-      return handleResponseWithStatus(
-        () => fetch(url, { headers: { Accept: kCSLJsonFormat } })
-      );
+      return handleResponseWithStatus(async () => {
+        const response = await fetch(url, { headers: { Accept: kCSLJsonFormat } });
+
+        // some registration agencies don't support CSL content negotiation;
+        // for those DOIs the request just redirects to the (HTML) landing
+        // page, so report that rather than failing to parse the page as JSON
+        const contentType = response.headers.get("Content-Type") || "";
+        if (response.ok && !contentType.includes("json")) {
+          throw new Error(
+            "This DOI resolved, but its registration agency does not provide citation metadata."
+          );
+        }
+
+        return response;
+      });
     }
   }
 }

--- a/packages/editor-server/src/server/doi.ts
+++ b/packages/editor-server/src/server/doi.ts
@@ -37,7 +37,9 @@ export function doiServer() : DOIServer {
         const contentType = response.headers.get("Content-Type") || "";
         if (response.ok && !contentType.includes("json")) {
           throw new Error(
-            "This DOI resolved, but its registration agency does not provide citation metadata."
+            "This DOI was found, but no citation data is available for it. " +
+            "This usually means the organization that registered the DOI does not support automatic citation lookup. " +
+            "To cite this work, you can add an entry to your bibliography manually."
           );
         }
 


### PR DESCRIPTION
When inserting a citation from a DOI, the lookup uses DOI content negotiation (an `Accept: application/vnd.citationstyles.csl+json` header against `https://doi.org/<doi>`). For DOIs whose registration agency does not support content negotiation (e.g. `10.1000/182`, the DOI Handbook itself), the request just redirects to the HTML landing page, and the editor surfaced a raw JSON parse error:

> invalid json response body at https://www.doi.org/the-identifier/resources/handbook/ reason: Unexpected token '<', "<!DOCTYPE "... is not valid JSON

This PR detects the "resolved, but not to JSON" case and reports a human-readable message instead:

> This DOI was found, but no citation data is available for it. This usually means the organization that registered the DOI does not support automatic citation lookup. To cite this work, you can add an entry to your bibliography manually.

Noticed while reviewing #1060 (https://github.com/quarto-dev/quarto/pull/1060#pullrequestreview-4767976245).

Verified manually by calling `doiServer().fetchCSL()` directly: `10.1000/182` now returns the friendly error, and a real Crossref DOI (`10.1038/nature12373`) still returns CSL metadata.