### PR TITLE
Ignore js-yaml merge advisory for real

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'

--- a/apps/lsp/.snyk
+++ b/apps/lsp/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'

--- a/apps/vscode-markdownit/.snyk
+++ b/apps/vscode-markdownit/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'

--- a/apps/vscode/.snyk
+++ b/apps/vscode/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'

--- a/packages/editor-server/.snyk
+++ b/packages/editor-server/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'

--- a/packages/editor/.snyk
+++ b/packages/editor/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'

--- a/packages/ojs/quarto-ojs-runtime/.snyk
+++ b/packages/ojs/quarto-ojs-runtime/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'

--- a/packages/quarto-core/.snyk
+++ b/packages/quarto-core/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-JSYAML-18313070:
+    - '*':
+        reason: >-
+          No fix exists in the js-yaml 4.x line as of 2026-07-27; the advisory is
+          fixed only in 5.2.2, and js-yaml 5.0.0 is a breaking rewrite (flat named
+          exports, YAML 1.2 number parsing instead of 1.1, reorganized schema
+          exports) that needs a deliberate migration rather than an automated bump.
+          Exposure here is limited: the affected parse path handles front matter and
+          config from documents the user has already opened locally, not untrusted
+          network input, so the worst case is a self-inflicted editor hang. Revisit
+          when a 4.x backport lands or the 5.x migration is scheduled.
+        expires: '2026-10-25T00:00:00.000Z'


### PR DESCRIPTION
Two advisories landed on 2026-07-27 and generated yet another seven Snyk fix PRs (#1064 through #1070).

SNYK-JS-JSYAML-18313070 (inefficient algorithmic complexity in readFlowCollection, CVSS 8.7) is fixed only in js-yaml 5.2.2. There is no backport in the 4.x line, so the lockfile re-resolution used in #1056 cannot reach it, and js-yaml 5.0.0 is a breaking rewrite (flat named exports, YAML 1.2 number parsing instead of 1.1, reorganized schema exports) that deserves a deliberate migration rather than an automated bump. This PR adds a `.snyk` policy ignoring the advisory with a 90-day expiry (2026-10-25). Snyk's GitHub integration reads `.snyk` per manifest directory rather than from the repo root, so the file is duplicated into each directory it scans as its own project, plus one at the root so local `snyk test` runs agree with CI.

Exposure is not very serious in the meantime. The affected parse path handles front matter and config from documents the user has already opened locally, not untrusted network input, so the worst case is a self-inflicted editor hang.

- Closes #1064
- Closes #1065
- Closes #1066
- Closes #1067
- Closes #1068
- Closes #1069
- Closes #1070
