### PR TITLE
"insert code cell" splits cell if cursor inside

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Reduce memory usage by only starting the language server (LSP) in projects containing Quarto documents (https://github.com/quarto-dev/quarto/pull/1059).
 - Fixed a bug where single-line display math with a cross-reference label (e.g. `$$1+1$$ {#eq-spec0}`), or an unclosed `$$`, stopped the rest of the document from being parsed, so headings went missing from the outline, LaTeX preview was unavailable, and code cells below could not be run (<https://github.com/quarto-dev/quarto/pull/1063>).
+- Make "insert cell" split the cell when cursor is inside, or insert a cell above when the cursor is at the top (<https://github.com/quarto-dev/quarto/pull/1086>).
 
 ## 1.135.0 (Release on 2026-07-08)
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1064,7 +1064,7 @@
           "order": 22,
           "scope": "window",
           "type": "integer",
-          "default": 250,
+          "default": 50,
           "markdownDescription": "Millisecond delay between background color updates."
         },
         "quarto.cells.useReticulate": {

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -231,7 +231,7 @@ class HiglightingConfig {
     }
 
     this.enabled_ = backgroundOption !== CellBackgroundColor.off;
-    this.delayMs_ = config.get("cells.background.delay", 250);
+    this.delayMs_ = config.get("cells.background.delay", 50);
 
 
     if (this.backgroundDecoration_) {
@@ -264,7 +264,7 @@ class HiglightingConfig {
   private enabled_ = true;
   private backgroundDecoration_: vscode.TextEditorDecorationType | undefined;
   private inlineBackgroundDecoration_: vscode.TextEditorDecorationType | undefined;
-  private delayMs_ = 250;
+  private delayMs_ = 50;
 }
 
 const highlightingConfig = new HiglightingConfig();

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -56,6 +56,15 @@ export function activateBackgroundHighlighter(
     context.subscriptions
   );
 
+  // release cached ranges when documents close
+  vscode.workspace.onDidCloseTextDocument(
+    (doc) => {
+      highlightRangesCache.delete(doc.uri.toString());
+    },
+    null,
+    context.subscriptions
+  );
+
   // update highlighting when visible text editors change
   vscode.window.onDidChangeVisibleTextEditors(
     (visibleEditors) => {
@@ -140,6 +149,53 @@ function updateAllEditorsDecorationsThrottled(engine: MarkdownEngine) {
   }
 }
 
+// computed ranges are cached by document version: updates are triggered
+// (among other things) by the document highlight provider, which fires on
+// every cursor move against an unchanged document
+const highlightRangesCache = new Map<string, {
+  version: number;
+  blockRanges: vscode.Range[];
+  inlineRanges: vscode.Range[];
+}>();
+
+function editorHighlightRanges(
+  editor: vscode.TextEditor,
+  engine: MarkdownEngine
+) {
+  const uri = editor.document.uri.toString();
+  const version = editor.document.version;
+  const cached = highlightRangesCache.get(uri);
+  if (cached && cached.version === version) {
+    return cached;
+  }
+
+  const blockRanges: vscode.Range[] = [];
+  const inlineRanges: vscode.Range[] = [];
+
+  // find code blocks
+  const tokens = engine.parse(editor.document);
+  for (const block of tokens.filter(isExecutableLanguageBlock)) {
+    blockRanges.push(vscRange(block.range));
+  }
+
+  // find inline executable code
+  for (let i = 0; i < editor.document.lineCount; i++) {
+    const line = editor.document.lineAt(i);
+    const matches = line.text.matchAll(/(^|[^`])`{[\w_]+}[ \t]([^`]+)`/g);
+    for (const match of matches) {
+      if (match.index !== undefined) {
+        const begin = new vscode.Position(i, match.index + match[1].length);
+        const end = new vscode.Position(i, begin.character + match[0].length - match[1].length);
+        inlineRanges.push(new vscode.Range(begin, end));
+      }
+    }
+  }
+
+  const ranges = { version, blockRanges, inlineRanges };
+  highlightRangesCache.set(uri, ranges);
+  return ranges;
+}
+
 async function setEditorHighlightDecorations(
   editor: vscode.TextEditor,
   engine: MarkdownEngine,
@@ -150,34 +206,11 @@ async function setEditorHighlightDecorations(
     return;
   }
 
-  // ranges to highlight
-  const blockRanges: vscode.Range[] = [];
-  const inlineRanges: vscode.Range[] = [];
+  // ranges to highlight (could be none if highlighting isn't enabled)
+  const { blockRanges, inlineRanges } = highlightingConfig.enabled()
+    ? editorHighlightRanges(editor, engine)
+    : { blockRanges: [], inlineRanges: [] };
 
-  if (highlightingConfig.enabled()) {
-
-    // find code blocks
-    const tokens = engine.parse(editor.document);
-    for (const block of tokens.filter(isExecutableLanguageBlock)) {
-      blockRanges.push(vscRange(block.range));
-    }
-
-    // find inline executable code
-    for (let i = 0; i < editor.document.lineCount; i++) {
-      const line = editor.document.lineAt(i);
-      const matches = line.text.matchAll(/(^|[^`])`{[\w_]+}[ \t]([^`]+)`/g);
-      for (const match of matches) {
-        if (match.index !== undefined) {
-          const begin = new vscode.Position(i, match.index + match[1].length);
-          const end = new vscode.Position(i, begin.character + match[0].length - match[1].length);
-          inlineRanges.push(new vscode.Range(begin, end));
-        }
-      }
-    }
-  }
-
-
-  // set highlights (could be none if we highlighting isn't enabled)
   editor.setDecorations(
     highlightingConfig.backgroundDecoration(),
     blockRanges

--- a/apps/vscode/src/providers/div-brackets.ts
+++ b/apps/vscode/src/providers/div-brackets.ts
@@ -50,7 +50,7 @@ export function activateDivBracketDecorations(context: vscode.ExtensionContext) 
 
   // Read debounce delay from config
   const getDelayMs = () =>
-    vscode.workspace.getConfiguration('quarto').get('cells.background.delay', 250);
+    vscode.workspace.getConfiguration('quarto').get('cells.background.delay', 50);
 
   // Cache for parsed tokens
   const parseCache = new Map<string, {

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -18,11 +18,13 @@ import {
   window,
   Range,
   Position,
+  Selection,
+  TextEditor,
 } from "vscode";
 import { Command } from "../core/command";
 import { isQuartoDoc } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
-import { isExecutableLanguageBlock, languageBlockAtPosition, languageNameFromBlock } from "quarto-core";
+import { Token, isExecutableLanguageBlock, languageBlockAtPosition, languageNameFromBlock } from "quarto-core";
 import { tryAcquirePositronApi } from "@posit-dev/positron";
 
 
@@ -37,19 +39,26 @@ class InsertCodeCellCommand implements Command {
 
   async execute(): Promise<void> {
     if (window.activeTextEditor) {
-      const doc = window.activeTextEditor?.document;
+      const editor = window.activeTextEditor;
+      const doc = editor.document;
       if (doc && isQuartoDoc(doc)) {
 
         // determine most recently used language engien above the cursor
         const tokens = this.engine_.parse(doc);
-        const cursorLine = window.activeTextEditor?.selection.active.line;
+        const cursorLine = editor.selection.active.line;
         let language = "";
         let insertTopPaddingLine = false;
 
         const pos = new Position(cursorLine, 0);
         const block = languageBlockAtPosition(tokens, pos, true);
         if (block) {
-          // cursor is in an executable block
+          // cursor is in an executable block: split it into two cells at the
+          // cursor (or three around the selection), like RStudio does
+          if (await splitCodeCell(editor, block)) {
+            return;
+          }
+          // block isn't a backtick code fence (e.g. display math), so
+          // insert a new cell below it
           language = languageNameFromBlock(block);
           insertTopPaddingLine = true;
           const moveDown = block.range.end.line - cursorLine + 1;
@@ -131,4 +140,104 @@ class InsertCodeCellCommand implements Command {
       }
     }
   }
+}
+
+// split the code cell containing the cursor into two cells at the cursor line
+// (with a selection, into three cells: before / selection / after), mirroring
+// RStudio's insert chunk behavior. returns false if the block isn't a backtick
+// code fence (e.g. display math) and so can't be split
+async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean> {
+  const doc = editor.document;
+  const headerLine = block.range.start.line;
+  const header = doc.lineAt(headerLine).text;
+  const fenceMatch = header.match(/^(`{3,})\s*\{/);
+  if (!fenceMatch) {
+    return false;
+  }
+  const fence = fenceMatch[1];
+
+  // locate the closing fence: the parsed range can end one line past it (when
+  // the next line has content) or the block may be unclosed at end of document
+  const closingFenceRegex = new RegExp("^ {0,3}`{" + fence.length + ",}\\s*$");
+  let footerLine = Math.min(block.range.end.line, doc.lineCount - 1);
+  while (footerLine > headerLine && !closingFenceRegex.test(doc.lineAt(footerLine).text)) {
+    footerLine--;
+  }
+  const closed = footerLine > headerLine;
+  const blockEndLine = closed ? footerLine : Math.min(block.range.end.line, doc.lineCount - 1);
+  if (blockEndLine <= headerLine) {
+    // header-only block with no body to split
+    return false;
+  }
+  const bodyStart = new Position(headerLine + 1, 0);
+  const bodyEnd = closed
+    ? new Position(footerLine, 0)
+    : new Position(blockEndLine, doc.lineAt(blockEndLine).text.length);
+
+  // determine the split point(s): the cursor line with no selection, otherwise
+  // the selection boundaries (clamped to the cell body)
+  const clamp = (p: Position) =>
+    p.isBefore(bodyStart) ? bodyStart : p.isAfter(bodyEnd) ? bodyEnd : p;
+  const selection = editor.selection;
+  let splitStart: Position;
+  let splitEnd: Position;
+  if (selection.isEmpty) {
+    splitStart = splitEnd = clamp(new Position(selection.active.line, 0));
+  } else {
+    splitStart = clamp(selection.start);
+    splitEnd = clamp(selection.end);
+  }
+
+  // cell bodies, with surrounding blank lines removed (but indentation kept)
+  const cellBody = (range: Range) => {
+    const text = doc
+      .getText(range)
+      .replace(/^([ \t]*\n)+/, "")
+      .replace(/(\n[ \t]*)+$/, "");
+    return text.trim() ? text : "";
+  };
+  const before = cellBody(new Range(bodyStart, splitStart));
+  const middle = cellBody(new Range(splitStart, splitEnd));
+  const after = cellBody(new Range(splitEnd, bodyEnd));
+
+  // assemble the new cells and pick the one that should receive the cursor
+  const bodies: string[] = [];
+  let cursorCell: number;
+  if (splitStart.isEqual(splitEnd)) {
+    bodies.push(before, after);
+    // when everything ends up in the second cell the first (empty) cell is
+    // the new one, so put the cursor there
+    cursorCell = !before && after ? 0 : 1;
+  } else {
+    if (before) {
+      bodies.push(before);
+    }
+    cursorCell = bodies.length;
+    bodies.push(middle);
+    if (after) {
+      bodies.push(after);
+    }
+  }
+
+  // render the cells (empty cells get a blank line for the cursor to land on)
+  const cellText = (body: string) => header + "\n" + body + "\n" + fence;
+  const newText = bodies.map(cellText).join("\n\n");
+
+  // cursor goes to the first body line of the target cell
+  let cursorLine = headerLine + 1;
+  for (let i = 0; i < cursorCell; i++) {
+    cursorLine += (bodies[i] ? bodies[i].split("\n").length : 1) + 3;
+  }
+
+  const replaceRange = new Range(
+    new Position(headerLine, 0),
+    closed ? new Position(footerLine, doc.lineAt(footerLine).text.length) : bodyEnd
+  );
+  const applied = await editor.edit((edit) => edit.replace(replaceRange, newText));
+  if (applied) {
+    const cursor = new Position(cursorLine, 0);
+    editor.selection = new Selection(cursor, cursor);
+    editor.revealRange(new Range(cursor, cursor));
+  }
+  return true;
 }

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -226,9 +226,12 @@ async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean>
     }
   }
 
-  // render the cells (empty cells get a blank line for the cursor to land on)
+  // render the cells (empty cells get a blank line for the cursor to land on).
+  const defaultHeader = fence + "{" + languageNameFromBlock(block) + "}";
+  const firstCellWithBody = Math.max(bodies.findIndex((body) => body.length > 0), 0);
   const eol = doc.eol === EndOfLine.CRLF ? "\r\n" : "\n";
-  const cellText = (body: string) => header + eol + body + eol + fence;
+  const cellText = (body: string, i: number) =>
+    (i === firstCellWithBody ? header : defaultHeader) + eol + body + eol + fence;
   const newText = bodies.map(cellText).join(eol + eol);
 
   // cursor goes to the first body line of the target cell

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -58,8 +58,8 @@ class InsertCodeCellCommand implements Command {
           if (await splitCodeCell(editor, block)) {
             return;
           }
-          // block isn't a backtick code fence (e.g. display math), so
-          // insert a new cell below it
+          // block can't be split (e.g. display math or an unclosed fence),
+          // so insert a new cell below it
           language = languageNameFromBlock(block);
           insertTopPaddingLine = true;
           const moveDown = block.range.end.line - cursorLine + 1;
@@ -145,8 +145,8 @@ class InsertCodeCellCommand implements Command {
 
 // split the code cell containing the cursor into two cells at the cursor line
 // (with a selection, into three cells: before / selection / after), mirroring
-// RStudio's insert chunk behavior. returns false if the block isn't a backtick
-// code fence (e.g. display math) and so can't be split
+// RStudio's insert chunk behavior. returns false if the block isn't a closed
+// backtick code fence (e.g. display math) and so can't be split
 async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean> {
   const doc = editor.document;
   const headerLine = block.range.start.line;
@@ -158,22 +158,18 @@ async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean>
   const fence = fenceMatch[1];
 
   // locate the closing fence: the parsed range can end one line past it (when
-  // the next line has content) or the block may be unclosed at end of document
+  // the next line has content)
   const closingFenceRegex = new RegExp("^ {0,3}`{" + fence.length + ",}\\s*$");
   let footerLine = Math.min(block.range.end.line, doc.lineCount - 1);
   while (footerLine > headerLine && !closingFenceRegex.test(doc.lineAt(footerLine).text)) {
     footerLine--;
   }
-  const closed = footerLine > headerLine;
-  const blockEndLine = closed ? footerLine : Math.min(block.range.end.line, doc.lineCount - 1);
-  if (blockEndLine <= headerLine) {
-    // header-only block with no body to split
+  if (footerLine <= headerLine) {
+    // an unclosed fence parses to the end of the document
     return false;
   }
   const bodyStart = new Position(headerLine + 1, 0);
-  const bodyEnd = closed
-    ? new Position(footerLine, 0)
-    : new Position(blockEndLine, doc.lineAt(blockEndLine).text.length);
+  const bodyEnd = new Position(footerLine, 0);
 
   // determine the split point(s): the cursor line with no selection, otherwise
   // the selection boundaries (clamped to the cell body)
@@ -242,7 +238,7 @@ async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean>
 
   const replaceRange = new Range(
     new Position(headerLine, 0),
-    closed ? new Position(footerLine, doc.lineAt(footerLine).text.length) : bodyEnd
+    new Position(footerLine, doc.lineAt(footerLine).text.length)
   );
   const applied = await editor.edit((edit) => edit.replace(replaceRange, newText));
   if (applied) {

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -16,6 +16,7 @@
 import {
   commands,
   window,
+  EndOfLine,
   Range,
   Position,
   Selection,
@@ -192,8 +193,8 @@ async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean>
   const cellBody = (range: Range) => {
     const text = doc
       .getText(range)
-      .replace(/^([ \t]*\n)+/, "")
-      .replace(/(\n[ \t]*)+$/, "");
+      .replace(/^([ \t]*\r?\n)+/, "")
+      .replace(/(\r?\n[ \t]*)+$/, "");
     return text.trim() ? text : "";
   };
   const before = cellBody(new Range(bodyStart, splitStart));
@@ -220,8 +221,9 @@ async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean>
   }
 
   // render the cells (empty cells get a blank line for the cursor to land on)
-  const cellText = (body: string) => header + "\n" + body + "\n" + fence;
-  const newText = bodies.map(cellText).join("\n\n");
+  const eol = doc.eol === EndOfLine.CRLF ? "\r\n" : "\n";
+  const cellText = (body: string) => header + eol + body + eol + fence;
+  const newText = bodies.map(cellText).join(eol + eol);
 
   // cursor goes to the first body line of the target cell
   let cursorLine = headerLine + 1;

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -249,6 +249,7 @@ async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean>
     const cursor = new Position(cursorLine, 0);
     editor.selection = new Selection(cursor, cursor);
     editor.revealRange(new Range(cursor, cursor));
+    return true;
   }
-  return true;
+  return false;
 }

--- a/apps/vscode/src/providers/insert.ts
+++ b/apps/vscode/src/providers/insert.ts
@@ -185,8 +185,14 @@ async function splitCodeCell(editor: TextEditor, block: Token): Promise<boolean>
   if (selection.isEmpty) {
     splitStart = splitEnd = clamp(new Position(selection.active.line, 0));
   } else {
-    splitStart = clamp(selection.start);
-    splitEnd = clamp(selection.end);
+    // snap the selection to whole lines
+    // (notean end position at column 0 belongs to the previous line)
+    splitStart = clamp(new Position(selection.start.line, 0));
+    const endLine =
+      selection.end.character === 0
+        ? selection.end.line
+        : selection.end.line + 1;
+    splitEnd = clamp(new Position(endLine, 0));
   }
 
   // cell bodies, with surrounding blank lines removed (but indentation kept)

--- a/apps/vscode/src/test/insert.test.ts
+++ b/apps/vscode/src/test/insert.test.ts
@@ -75,6 +75,153 @@ suite("Insert Code Cell", function () {
     });
   });
 
+  suite("Splitting the cell at the cursor", function () {
+    const PYTHON_CELL_DOC = [
+      "---",
+      "title: Test",
+      "---",
+      "",
+      "```{python}",  // line 4
+      "1 + 1",        // line 5
+      "",             // line 6
+      "2 + 2",        // line 7
+      "```",          // line 8
+      "",
+    ].join("\n");
+
+    test("Splits the cell in two when cursor is between statements", async function () {
+      const { doc, editor } = await openTestDocument("insert-test-split.qmd", PYTHON_CELL_DOC);
+
+      editor.selection = new vscode.Selection(6, 0, 6, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(
+        doc.getText(),
+        [
+          "---",
+          "title: Test",
+          "---",
+          "",
+          "```{python}",
+          "1 + 1",
+          "```",
+          "",
+          "```{python}",
+          "2 + 2",
+          "```",
+          "",
+        ].join("\n")
+      );
+      // cursor lands at the start of the second cell's body
+      assert.deepStrictEqual(
+        [editor.selection.active.line, editor.selection.active.character],
+        [9, 0]
+      );
+    });
+
+    test("Inserts an empty cell above when cursor is on the first line of the cell body", async function () {
+      const { doc, editor } = await openTestDocument("insert-test-split-above.qmd", PYTHON_CELL_DOC);
+
+      editor.selection = new vscode.Selection(5, 0, 5, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(
+        doc.getText(),
+        [
+          "---",
+          "title: Test",
+          "---",
+          "",
+          "```{python}",
+          "",
+          "```",
+          "",
+          "```{python}",
+          "1 + 1",
+          "",
+          "2 + 2",
+          "```",
+          "",
+        ].join("\n")
+      );
+      // cursor lands in the new empty cell
+      assert.deepStrictEqual(
+        [editor.selection.active.line, editor.selection.active.character],
+        [5, 0]
+      );
+    });
+
+    test("Inserts an empty cell below when cursor is on the closing fence", async function () {
+      const { doc, editor } = await openTestDocument("insert-test-split-below.qmd", PYTHON_CELL_DOC);
+
+      editor.selection = new vscode.Selection(8, 0, 8, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(
+        doc.getText(),
+        [
+          "---",
+          "title: Test",
+          "---",
+          "",
+          "```{python}",
+          "1 + 1",
+          "",
+          "2 + 2",
+          "```",
+          "",
+          "```{python}",
+          "",
+          "```",
+          "",
+        ].join("\n")
+      );
+      // cursor lands in the new empty cell
+      assert.deepStrictEqual(
+        [editor.selection.active.line, editor.selection.active.character],
+        [11, 0]
+      );
+    });
+
+    test("Splits the cell in three around a selection", async function () {
+      const content = [
+        "```{python}",  // line 0
+        "a = 1",        // line 1
+        "b = 2",        // line 2
+        "c = 3",        // line 3
+        "```",          // line 4
+        "",
+      ].join("\n");
+      const { doc, editor } = await openTestDocument("insert-test-split-selection.qmd", content);
+
+      editor.selection = new vscode.Selection(2, 0, 2, 5);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(
+        doc.getText(),
+        [
+          "```{python}",
+          "a = 1",
+          "```",
+          "",
+          "```{python}",
+          "b = 2",
+          "```",
+          "",
+          "```{python}",
+          "c = 3",
+          "```",
+          "",
+        ].join("\n")
+      );
+      // cursor lands in the cell holding the selected code
+      assert.deepStrictEqual(
+        [editor.selection.active.line, editor.selection.active.character],
+        [5, 0]
+      );
+    });
+  });
+
   suite("Language picker fallback", function () {
     test("Inserts a code fence when document has no executable code cells", async function () {
       const content = "---\ntitle: Test\n---\n\nJust some markdown.\n";
@@ -93,4 +240,12 @@ suite("Insert Code Cell", function () {
 
 function countOccurrences(text: string, substring: string): number {
   return text.split(substring).length - 1;
+}
+
+async function openTestDocument(fileName: string, content: string) {
+  const uri = examplesOutUri(fileName);
+  await vscode.workspace.fs.writeFile(uri, Buffer.from(content, "utf8") as Uint8Array);
+  const doc = await vscode.workspace.openTextDocument(uri);
+  const editor = await vscode.window.showTextDocument(doc);
+  return { doc, editor };
 }

--- a/apps/vscode/src/test/insert.test.ts
+++ b/apps/vscode/src/test/insert.test.ts
@@ -76,7 +76,7 @@ suite("Insert Code Cell", function () {
   });
 
   suite("Splitting the cell at the cursor", function () {
-    const PYTHON_CELL_DOC = [
+    const PYTHON_CELL_LINES = [
       "---",
       "title: Test",
       "---",
@@ -87,7 +87,8 @@ suite("Insert Code Cell", function () {
       "2 + 2",        // line 7
       "```",          // line 8
       "",
-    ].join("\n");
+    ];
+    const PYTHON_CELL_DOC = PYTHON_CELL_LINES.join("\n");
 
     test("Splits the cell in two when cursor is between statements", async function () {
       const { doc, editor } = await openTestDocument("insert-test-split.qmd", PYTHON_CELL_DOC);
@@ -219,6 +220,87 @@ suite("Insert Code Cell", function () {
         [editor.selection.active.line, editor.selection.active.character],
         [5, 0]
       );
+    });
+
+    test("Copies a labeled header to only the first cell", async function () {
+      const content = [
+        "```{r setup, include=FALSE}",  // line 0
+        "x <- 1",                       // line 1
+        "",                             // line 2
+        "y <- 2",                       // line 3
+        "```",                          // line 4
+        "",
+      ].join("\n");
+      const { doc, editor } = await openTestDocument("insert-test-split-label.qmd", content);
+
+      editor.selection = new vscode.Selection(2, 0, 2, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      // duplicating the header would duplicate the chunk label, so the second
+      // cell gets a bare language header
+      assert.strictEqual(
+        doc.getText(),
+        [
+          "```{r setup, include=FALSE}",
+          "x <- 1",
+          "```",
+          "",
+          "```{r}",
+          "y <- 2",
+          "```",
+          "",
+        ].join("\n")
+      );
+    });
+
+    test("Preserves CRLF line endings without mixing in LF", async function () {
+      const { doc, editor } = await openTestDocument(
+        "insert-test-split-crlf.qmd",
+        PYTHON_CELL_LINES.join("\r\n")
+      );
+
+      editor.selection = new vscode.Selection(6, 0, 6, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      assert.strictEqual(
+        doc.getText(),
+        [
+          "---",
+          "title: Test",
+          "---",
+          "",
+          "```{python}",
+          "1 + 1",
+          "```",
+          "",
+          "```{python}",
+          "2 + 2",
+          "```",
+          "",
+        ].join("\r\n")
+      );
+      // no bare LF anywhere in the document
+      assert.ok(!/[^\r]\n/.test(doc.getText()));
+    });
+
+    test("Does not split an unclosed cell; inserts a new cell below instead", async function () {
+      const content = [
+        "```{python}",  // line 0 (fence is never closed)
+        "1 + 1",        // line 1
+        "",             // line 2
+        "Some prose.",  // line 3
+        "",
+      ].join("\n");
+      const { doc, editor } = await openTestDocument("insert-test-unclosed.qmd", content);
+
+      editor.selection = new vscode.Selection(2, 0, 2, 0);
+      await vscode.commands.executeCommand("quarto.insertCodeCell");
+
+      // an unclosed fence parses to the end of the document; splitting it
+      // would pull the prose into a code cell, so the block is left untouched
+      // and the new cell goes below it
+      assert.ok(doc.getText().startsWith("```{python}\n1 + 1\n\nSome prose."));
+      assert.strictEqual(countOccurrences(doc.getText(), "```{python}"), 2);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/quarto-dev/quarto/issues/382

https://github.com/user-attachments/assets/43477964-8218-42f1-8637-6babc04a2f8d

Improves the "insert code cell" functionality to split cell when cursor is inside, or insert cell above when cursor is at top. Also splits three ways when there is a selection (not shown in video).

Tested in both VSCode and Positron.

## Design considerations

- An LLM looked up the RStudio source code for "insert code cell" as the reference implementation for this feature. The functionality should match RStudio.

- I lowered the background highlighting delay ms in this PR from 250ms to 50ms because 250s looked disorientingly jarring when splitting code cells. I don't know how reasonable this is to do, but it seems much nicer in general if people's computers can handle it. RStudio has very fast background highlighting so its nice if the experience in VSCode and Positron can try to match that.