### PR TITLE
#| highlighting alternative

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Reduce memory usage by only starting the language server (LSP) in projects containing Quarto documents (https://github.com/quarto-dev/quarto/pull/1059).
 - Fixed a bug where single-line display math with a cross-reference label (e.g. `$$1+1$$ {#eq-spec0}`), or an unclosed `$$`, stopped the rest of the document from being parsed, so headings went missing from the outline, LaTeX preview was unavailable, and code cells below could not be run (<https://github.com/quarto-dev/quarto/pull/1063>).
+- Add highlighting for option comments in code cells (<https://github.com/quarto-dev/quarto/pull/1084>).
 
 ## 1.135.0 (Release on 2026-07-08)
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1067,6 +1067,13 @@
           "default": 250,
           "markdownDescription": "Millisecond delay between background color updates."
         },
+        "quarto.cells.options.background": {
+          "order": 23,
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Apply a visual treatment to cell option comments (e.g. `#|` lines): a slightly darker background, dimmed text, and a separator below the options."
+        },
         "quarto.cells.useReticulate": {
           "order": 27,
           "scope": "window",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1072,7 +1072,7 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Apply a visual treatment to cell option comments (e.g. `#|` lines): a slightly darker background, dimmed text, and a separator below the options."
+          "markdownDescription": "Apply a visual treatment to cell option comments such as `#|` lines: a slightly darker background, dimmed text, and a separator below the options. When `#quarto.cells.background.color#` is `off`, this setting has no effect."
         },
         "quarto.cells.useReticulate": {
           "order": 27,

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1495,7 +1495,7 @@
     "build": "tsx build.ts",
     "dev": "yarn run build dev",
     "lint": "eslint src --ext ts",
-    "build-lang": "node syntaxes/build-lang",
+    "build-lang": "tsx syntaxes/build-lang.js",
     "build-test": "yarn run build test",
     "test": "yarn build-test && vscode-test",
     "test-positron": "yarn build-test && node ./scripts/run-positron-tests.mjs"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -995,28 +995,28 @@
           ]
         },
         "quarto.cells.hoverHelp.enabled": {
-          "order": 23,
+          "order": 24,
           "scope": "window",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Show help when hovering over functions."
         },
         "quarto.cells.signatureHelp.enabled": {
-          "order": 24,
+          "order": 25,
           "scope": "window",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Show parameter help when editing function calls."
         },
         "quarto.cells.diagnostics.enabled": {
-          "order": 25,
+          "order": 26,
           "scope": "window",
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable diagnostics (linting) for code blocks from language servers."
         },
         "quarto.cells.diagnostics.debounceDelay": {
-          "order": 26,
+          "order": 27,
           "scope": "window",
           "type": "number",
           "default": 500,
@@ -1075,7 +1075,7 @@
           "markdownDescription": "Apply a visual treatment to cell option comments such as `#|` lines: a slightly darker background, dimmed text, and a separator below the options. When `#quarto.cells.background.color#` is `off`, this setting has no effect."
         },
         "quarto.cells.useReticulate": {
-          "order": 27,
+          "order": 28,
           "scope": "window",
           "type": "boolean",
           "default": true,

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -212,6 +212,7 @@ async function setEditorHighlightDecorations(
 
 function clearEditorHighlightDecorations(editor: vscode.TextEditor) {
   editor.setDecorations(highlightingConfig.backgroundDecoration(), []);
+  editor.setDecorations(highlightingConfig.inlineBackgroundDecoration(), []);
   editor.setDecorations(cellOptionsBackgroundDecoration, []);
   editor.setDecorations(cellOptionsSeparatorDecoration, []);
 }

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -153,13 +153,28 @@ async function setEditorHighlightDecorations(
   // ranges to highlight
   const blockRanges: vscode.Range[] = [];
   const inlineRanges: vscode.Range[] = [];
+  const optionLineRanges: vscode.Range[] = [];
+  const optionSeparatorRanges: vscode.Range[] = [];
 
   if (highlightingConfig.enabled()) {
 
     // find code blocks
     const tokens = engine.parse(editor.document);
     for (const block of tokens.filter(isExecutableLanguageBlock)) {
-      blockRanges.push(vscRange(block.range));
+      const blockRange = vscRange(block.range);
+      blockRanges.push(blockRange);
+
+      // cell options (#| comments) get a darker background, and the last
+      // option line gets a separator (rendered as a bottom border)
+      const lines = hashPipeLines(editor.document, blockRange);
+      for (const line of lines) {
+        optionLineRanges.push(editor.document.lineAt(line).range);
+      }
+      if (lines.length > 0) {
+        optionSeparatorRanges.push(
+          editor.document.lineAt(lines[lines.length - 1]).range
+        );
+      }
     }
 
     // find inline executable code
@@ -186,10 +201,75 @@ async function setEditorHighlightDecorations(
     highlightingConfig.inlineBackgroundDecoration(),
     inlineRanges
   );
+  editor.setDecorations(cellOptionsBackgroundDecoration, optionLineRanges);
+  editor.setDecorations(cellOptionsSeparatorDecoration, optionSeparatorRanges);
 }
 
 function clearEditorHighlightDecorations(editor: vscode.TextEditor) {
   editor.setDecorations(highlightingConfig.backgroundDecoration(), []);
+  editor.setDecorations(cellOptionsBackgroundDecoration, []);
+  editor.setDecorations(cellOptionsSeparatorDecoration, []);
+}
+
+// these composite on top of the cell background decoration, so a
+// translucent black overlay reads as "slightly darker" in both themes
+// (the text is also slightly dimmed to de-emphasize options vs. code)
+const cellOptionsBackgroundDecoration = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  opacity: "0.75",
+  light: {
+    backgroundColor: "#00000012",
+  },
+  dark: {
+    backgroundColor: "#00000033",
+  },
+});
+
+// the separator is rendered via an "after" attachment (absolutely
+// positioned to span the bottom of the row) rather than a border on the
+// line itself: vscode applies line decorations to every visual row of a
+// soft-wrapped line, which would repeat the border on each wrapped row,
+// while an attachment is placed once, after the line's content
+const cellOptionsSeparatorDecoration = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  after: {
+    contentText: "",
+    textDecoration:
+      "none; position: absolute; left: 0; bottom: 0; width: 100vw; border-bottom: 1px solid;",
+  },
+  light: {
+    after: {
+      borderColor: "#00000025",
+    },
+  },
+  dark: {
+    after: {
+      borderColor: "#FFFFFF25",
+    },
+  },
+});
+
+// document lines of the leading run of cell option (#|) comments in a cell
+// (same pattern as the tmLanguage rule in ../../syntaxes/build-lang.js:
+// optional leading whitespace, then "#|" or "# |")
+//
+// note: this only handles #-comment languages (r, python, julia, etc.).
+// to generalize to all languages (//| for js, --| for sql, /*| ... */
+// for c, etc.), derive the prefix from the block's language using
+// kLangCommentChars/optionCommentPattern in packages/core/src/jupyter/options.ts
+function hashPipeLines(
+  document: vscode.TextDocument,
+  blockRange: vscode.Range
+): number[] {
+  const lines: number[] = [];
+  const lastLine = Math.min(blockRange.end.line, document.lineCount - 1);
+  for (let i = blockRange.start.line + 1; i <= lastLine; i++) {
+    if (!/^\s*# ?\|/.test(document.lineAt(i).text)) {
+      break;
+    }
+    lines.push(i);
+  }
+  return lines;
 }
 
 enum CellBackgroundColor {

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -19,9 +19,10 @@ import * as vscode from "vscode";
 
 import { isQuartoDoc, kQuartoDocSelector } from "../core/doc";
 import { MarkdownEngine } from "../markdown/engine";
-import { isExecutableLanguageBlock } from "quarto-core";
+import { isExecutableLanguageBlock, languageNameFromBlock } from "quarto-core";
 import { vscRange } from "../core/range";
 import { createThrottle } from "../core/throttle";
+import { langCommentChars, optionCommentPattern } from "./cell/comment-chars";
 
 export function activateBackgroundHighlighter(
   context: vscode.ExtensionContext,
@@ -166,7 +167,11 @@ async function setEditorHighlightDecorations(
 
       // cell options (#| comments) get a darker background, and the last
       // option line gets a separator (rendered as a bottom border)
-      const lines = hashPipeLines(editor.document, blockRange);
+      const lines = cellOptionLines(
+        editor.document,
+        blockRange,
+        languageNameFromBlock(block)
+      );
       for (const line of lines) {
         optionLineRanges.push(editor.document.lineAt(line).range);
       }
@@ -249,22 +254,29 @@ const cellOptionsSeparatorDecoration = vscode.window.createTextEditorDecorationT
   },
 });
 
-// document lines of the leading run of cell option (#|) comments in a cell
-// (same pattern as the tmLanguage rule in ../../syntaxes/build-lang.js:
-// optional leading whitespace, then "#|" or "# |")
+// document lines of the leading run of cell option comments in a cell
+// (#| for python/r, //| for js, etc. -- the same pattern used by the
+// tmLanguage rules generated in ../../syntaxes/build-lang.js, with
+// optional leading indentation allowed)
 //
-// note: this only handles #-comment languages (r, python, julia, etc.).
-// to generalize to all languages (//| for js, --| for sql, /*| ... */
-// for c, etc.), derive the prefix from the block's language using
-// kLangCommentChars/optionCommentPattern in packages/core/src/jupyter/options.ts
-function hashPipeLines(
+// note: block-comment languages (e.g. /*| ... */ for c and css) are not
+// supported (same as the tmLanguage)
+function cellOptionLines(
   document: vscode.TextDocument,
-  blockRange: vscode.Range
+  blockRange: vscode.Range,
+  language: string
 ): number[] {
+  const commentChars = langCommentChars(language);
+  if (commentChars.length > 1) {
+    return [];
+  }
+  const pattern = new RegExp(
+    "^\\s*" + optionCommentPattern(commentChars[0]).source.replace(/^\^/, "")
+  );
   const lines: number[] = [];
   const lastLine = Math.min(blockRange.end.line, document.lineCount - 1);
   for (let i = blockRange.start.line + 1; i <= lastLine; i++) {
-    if (!/^\s*# ?\|/.test(document.lineAt(i).text)) {
+    if (!pattern.test(document.lineAt(i).text)) {
       break;
     }
     lines.push(i);

--- a/apps/vscode/src/providers/background.ts
+++ b/apps/vscode/src/providers/background.ts
@@ -167,18 +167,20 @@ async function setEditorHighlightDecorations(
 
       // cell options (#| comments) get a darker background, and the last
       // option line gets a separator (rendered as a bottom border)
-      const lines = cellOptionLines(
-        editor.document,
-        blockRange,
-        languageNameFromBlock(block)
-      );
-      for (const line of lines) {
-        optionLineRanges.push(editor.document.lineAt(line).range);
-      }
-      if (lines.length > 0) {
-        optionSeparatorRanges.push(
-          editor.document.lineAt(lines[lines.length - 1]).range
+      if (highlightingConfig.cellOptionsBackgroundEnabled()) {
+        const lines = cellOptionLines(
+          editor.document,
+          blockRange,
+          languageNameFromBlock(block)
         );
+        for (const line of lines) {
+          optionLineRanges.push(editor.document.lineAt(line).range);
+        }
+        if (lines.length > 0) {
+          optionSeparatorRanges.push(
+            editor.document.lineAt(lines[lines.length - 1]).range
+          );
+        }
       }
     }
 
@@ -298,6 +300,10 @@ class HiglightingConfig {
     return this.enabled_;
   }
 
+  public cellOptionsBackgroundEnabled() {
+    return this.cellOptionsBackground_;
+  }
+
   public backgroundDecoration() {
     return this.backgroundDecoration_!;
   }
@@ -324,6 +330,7 @@ class HiglightingConfig {
     }
 
     this.enabled_ = backgroundOption !== CellBackgroundColor.off;
+    this.cellOptionsBackground_ = config.get<boolean>("cells.options.background", true);
     this.delayMs_ = config.get("cells.background.delay", 250);
 
 
@@ -355,6 +362,7 @@ class HiglightingConfig {
   }
 
   private enabled_ = true;
+  private cellOptionsBackground_ = true;
   private backgroundDecoration_: vscode.TextEditorDecorationType | undefined;
   private inlineBackgroundDecoration_: vscode.TextEditorDecorationType | undefined;
   private delayMs_ = 250;

--- a/apps/vscode/src/providers/cell/comment-chars.ts
+++ b/apps/vscode/src/providers/cell/comment-chars.ts
@@ -1,0 +1,85 @@
+/*
+ * comment-chars.ts
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+// comment characters used for cell options by language (e.g. #| for
+// python/r, //| for js, --| for sql). pairs are block comment delimiters
+// (/*| ... */).
+//
+// note: this module must remain dependency-free: it is also imported by
+// syntaxes/build-lang.js to generate the cell option comment rules of the
+// quarto textmate grammar
+
+export const kLangCommentChars: Record<string, string | [string, string]> = {
+  r: "#",
+  python: "#",
+  julia: "#",
+  scala: "//",
+  matlab: "%",
+  csharp: "//",
+  fsharp: "//",
+  c: ["/*", "*/"],
+  css: ["/*", "*/"],
+  sas: ["*", ";"],
+  powershell: "#",
+  bash: "#",
+  sql: "--",
+  mysql: "--",
+  psql: "--",
+  lua: "--",
+  cpp: "//",
+  cc: "//",
+  stan: "#",
+  octave: "#",
+  fortran: "!",
+  fortran95: "!",
+  awk: "#",
+  gawk: "#",
+  stata: "*",
+  java: "//",
+  groovy: "//",
+  sed: "#",
+  perl: "#",
+  ruby: "#",
+  tikz: "%",
+  js: "//",
+  d3: "//",
+  node: "//",
+  sass: "//",
+  coffee: "#",
+  go: "//",
+  asy: "//",
+  haskell: "--",
+  dot: "//",
+  mermaid: "%%",
+  ojs: "//",
+  apl: "⍝",
+};
+
+export function langCommentChars(lang: string): string[] {
+  const chars = kLangCommentChars[lang] || "#";
+  if (!Array.isArray(chars)) {
+    return [chars];
+  } else {
+    return chars;
+  }
+}
+
+export function optionCommentPattern(comment: string) {
+  return new RegExp("^" + escapeRegExp(comment) + "\\s*\\| ?");
+}
+
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}

--- a/apps/vscode/src/providers/cell/options.ts
+++ b/apps/vscode/src/providers/cell/options.ts
@@ -19,6 +19,10 @@ import * as yaml from "js-yaml";
 import { lines } from "core";
 import { Token, isCodeBlock, languageNameFromBlock } from "quarto-core";
 
+import { langCommentChars, optionCommentPattern } from "./comment-chars";
+
+export { optionCommentPattern } from "./comment-chars";
+
 
 export const kExecuteEval = "eval";
 
@@ -83,63 +87,3 @@ export function cellOptions(language: string, source: string[]): Record<string, 
   }
 }
 
-function langCommentChars(lang: string): string[] {
-  const chars = kLangCommentChars[lang] || "#";
-  if (!Array.isArray(chars)) {
-    return [chars];
-  } else {
-    return chars;
-  }
-}
-export function optionCommentPattern(comment: string) {
-  return new RegExp("^" + escapeRegExp(comment) + "\\s*\\| ?");
-}
-
-const kLangCommentChars: Record<string, string | [string, string]> = {
-  r: "#",
-  python: "#",
-  julia: "#",
-  scala: "//",
-  matlab: "%",
-  csharp: "//",
-  fsharp: "//",
-  c: ["/*", "*/"],
-  css: ["/*", "*/"],
-  sas: ["*", ";"],
-  powershell: "#",
-  bash: "#",
-  sql: "--",
-  mysql: "--",
-  psql: "--",
-  lua: "--",
-  cpp: "//",
-  cc: "//",
-  stan: "#",
-  octave: "#",
-  fortran: "!",
-  fortran95: "!",
-  awk: "#",
-  gawk: "#",
-  stata: "*",
-  java: "//",
-  groovy: "//",
-  sed: "#",
-  perl: "#",
-  ruby: "#",
-  tikz: "%",
-  js: "//",
-  d3: "//",
-  node: "//",
-  sass: "//",
-  coffee: "#",
-  go: "//",
-  asy: "//",
-  haskell: "--",
-  dot: "//",
-  ojs: "//",
-  apl: "⍝",
-};
-
-function escapeRegExp(str: string) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
-}

--- a/apps/vscode/syntaxes/build-lang.js
+++ b/apps/vscode/syntaxes/build-lang.js
@@ -5,6 +5,14 @@ const path = require("path");
 const yaml = require("js-yaml");
 const plist = require("plist");
 
+// the cell option comment characters/pattern shared with the extension
+// itself (this is a typescript module: run this script with tsx)
+const {
+  kLangCommentChars,
+  langCommentChars,
+  optionCommentPattern,
+} = require("../src/providers/cell/comment-chars");
+
 const languages = [
   {
     name: "css",
@@ -449,6 +457,16 @@ const languages = [
   },
 ];
 
+// textmate-conventional scope suffixes for the option comment markers
+const kCommentScopeNames = {
+  "#": "number-sign",
+  "//": "double-slash",
+  "--": "double-dash",
+  "%": "percentage",
+  "*": "asterisk",
+  "!": "exclamation",
+};
+
 const fencedCodeBlockDefinition = (
   name,
   identifiers,
@@ -471,6 +489,44 @@ const fencedCodeBlockDefinition = (
     contentName += ` ${additionalContentName.join(" ")}`;
   }
 
+  // patterns for the cell content: the leading run of cell option comments
+  // (e.g. #| fig-cap: ...) is highlighted as yaml, then a second region
+  // claims the rest of the cell with only the language grammar, so option
+  // markers in the body of a cell stay ordinary comments. block-comment
+  // languages (e.g. /*| ... */ for c and css) are not supported: their
+  // closing delimiter would end up inside the yaml
+  const commentChars = langCommentChars(
+    name in kLangCommentChars ? name : language
+  );
+  let contentPatterns;
+  if (commentChars.length > 1) {
+    contentPatterns = indent(4, scopes);
+  } else {
+    // the runtime option pattern, sans its ^ anchor (the grammar allows
+    // leading indentation, and also reuses the marker inside a lookahead)
+    const marker = optionCommentPattern(commentChars[0]).source.replace(
+      /^\^/,
+      ""
+    );
+    const scope = `comment.line.${
+      kCommentScopeNames[commentChars[0]] || "cell-options"
+    }.quarto`;
+    contentPatterns = indent(
+      4,
+      `- begin: ^(\\s*)(${marker})
+  while: ^(\\s*)(${marker})
+  captures:
+    '2': {name: '${scope}'}
+  contentName: meta.embedded.block.yaml
+  patterns:
+    - {include: 'source.yaml'}
+- begin: ^(?!\\s*${marker})
+  while: (^|\\G)
+  patterns:
+${indent(2, scopes)}`
+    );
+  }
+
   return `fenced_code_block_${name}:
   begin:
     (^|\\G)(\\s*)(\`{3,}|~{3,})\\s*(?:\\{(?:#[\\w-]+\\s+)?[\\{\\.=]?)?(?i:(${identifiers.join(
@@ -491,14 +547,7 @@ const fencedCodeBlockDefinition = (
       while: (^|\\G)(?!\\s*([\`~]{3,})\\s*$)
       contentName: ${contentName}
       patterns:
-        - begin: ^(\\s*)(#\\|)
-          while: ^(\\s*)(#\\|)
-          captures:
-            '2': {name: 'comment.line.number-sign.quarto'}
-          contentName: meta.embedded.block.yaml
-          patterns:
-            - {include: 'source.yaml'}
-${indent(4, scopes)}
+${contentPatterns}
 `;
 };
 

--- a/apps/vscode/syntaxes/build-lang.js
+++ b/apps/vscode/syntaxes/build-lang.js
@@ -491,6 +491,13 @@ const fencedCodeBlockDefinition = (
       while: (^|\\G)(?!\\s*([\`~]{3,})\\s*$)
       contentName: ${contentName}
       patterns:
+        - begin: ^(\\s*)(#\\|)
+          while: ^(\\s*)(#\\|)
+          captures:
+            '2': {name: 'comment.line.number-sign.quarto'}
+          contentName: meta.embedded.block.yaml
+          patterns:
+            - {include: 'source.yaml'}
 ${indent(4, scopes)}
 `;
 };

--- a/apps/vscode/syntaxes/quarto.tmLanguage
+++ b/apps/vscode/syntaxes/quarto.tmLanguage
@@ -173,29 +173,6 @@
             <key>patterns</key>
             <array>
               <dict>
-                <key>begin</key>
-                <string>^(\s*)(#\|)</string>
-                <key>while</key>
-                <string>^(\s*)(#\|)</string>
-                <key>captures</key>
-                <dict>
-                  <key>2</key>
-                  <dict>
-                    <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
-                  </dict>
-                </dict>
-                <key>contentName</key>
-                <string>meta.embedded.block.yaml</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>include</key>
-                    <string>source.yaml</string>
-                  </dict>
-                </array>
-              </dict>
-              <dict>
                 <key>include</key>
                 <string>source.css</string>
               </dict>
@@ -250,9 +227,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -272,8 +249,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.html.basic</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.html.basic</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -326,9 +312,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -348,8 +334,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.ini</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.ini</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -402,15 +397,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -424,8 +419,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.java</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.java</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -478,15 +482,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(--\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(--\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-dash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -500,8 +504,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.lua</string>
+                <key>begin</key>
+                <string>^(?!\s*--\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.lua</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -554,9 +567,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -576,8 +589,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.makefile</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.makefile</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -630,9 +652,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -652,8 +674,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.perl</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.perl</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -706,9 +737,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -728,8 +759,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.prql</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.prql</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -782,9 +822,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -804,8 +844,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.r</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.r</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -858,9 +907,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -880,8 +929,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.julia</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.julia</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -934,15 +992,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(%\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(%\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.percentage.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -956,8 +1014,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.matlab</string>
+                <key>begin</key>
+                <string>^(?!\s*%\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.matlab</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1010,15 +1077,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\*\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\*\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.asterisk.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -1032,8 +1099,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.stata</string>
+                <key>begin</key>
+                <string>^(?!\s*\*\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.stata</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1086,15 +1162,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -1108,8 +1184,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.dot</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.dot</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1162,15 +1247,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(%%\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(%%\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.cell-options.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -1184,8 +1269,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.mmd</string>
+                <key>begin</key>
+                <string>^(?!\s*%%\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.mmd</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1238,9 +1332,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1260,8 +1354,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.wsd</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.wsd</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1314,9 +1417,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1336,8 +1439,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.ruby</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.ruby</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1390,9 +1502,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1412,12 +1524,21 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.html.basic</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>source.php</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.html.basic</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>source.php</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1470,15 +1591,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(--\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(--\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-dash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -1492,8 +1613,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.sql</string>
+                <key>begin</key>
+                <string>^(?!\s*--\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.sql</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1546,9 +1676,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1568,8 +1698,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.asp.vb.net</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.asp.vb.net</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1622,9 +1761,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1644,8 +1783,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.xml</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.xml</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1698,9 +1846,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1720,8 +1868,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.xml.xsl</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.xml.xsl</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1774,9 +1931,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1796,8 +1953,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.yaml</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1850,9 +2016,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1872,8 +2038,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.batchfile</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.batchfile</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -1926,9 +2101,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -1948,8 +2123,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.clojure</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.clojure</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2002,9 +2186,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2024,8 +2208,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.coffee</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.coffee</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2076,29 +2269,6 @@
             <string>meta.embedded.block.c</string>
             <key>patterns</key>
             <array>
-              <dict>
-                <key>begin</key>
-                <string>^(\s*)(#\|)</string>
-                <key>while</key>
-                <string>^(\s*)(#\|)</string>
-                <key>captures</key>
-                <dict>
-                  <key>2</key>
-                  <dict>
-                    <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
-                  </dict>
-                </dict>
-                <key>contentName</key>
-                <string>meta.embedded.block.yaml</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>include</key>
-                    <string>source.yaml</string>
-                  </dict>
-                </array>
-              </dict>
               <dict>
                 <key>include</key>
                 <string>source.c</string>
@@ -2154,15 +2324,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -2176,8 +2346,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.cpp</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.cpp</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2230,9 +2409,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2252,8 +2431,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.diff</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.diff</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2306,9 +2494,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2328,8 +2516,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.dockerfile</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.dockerfile</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2382,9 +2579,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2404,8 +2601,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.git-commit</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.git-commit</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2458,9 +2664,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2480,8 +2686,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.git-rebase</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.git-rebase</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2534,15 +2749,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -2556,8 +2771,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.go</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.go</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2610,15 +2834,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -2632,8 +2856,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.groovy</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.groovy</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2686,9 +2919,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2708,8 +2941,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.pug</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.pug</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2762,15 +3004,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -2784,8 +3026,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.js</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.js</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2838,9 +3089,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2860,8 +3111,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.js.regexp</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.js.regexp</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2914,9 +3174,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -2936,8 +3196,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.json</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.json</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -2990,9 +3259,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3012,8 +3281,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.json.comments</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.json.comments</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3066,9 +3344,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3088,8 +3366,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.css.less</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.css.less</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3142,9 +3429,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3164,8 +3451,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.objc</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.objc</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3218,9 +3514,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3240,8 +3536,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.swift</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.swift</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3294,9 +3599,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3316,8 +3621,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.css.scss</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.css.scss</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3370,9 +3684,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3392,8 +3706,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.perl.6</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.perl.6</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3446,9 +3769,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3468,8 +3791,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.powershell</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.powershell</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3522,9 +3854,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3544,8 +3876,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.stan</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.stan</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3598,9 +3939,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3620,8 +3961,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.python</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.python</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3674,9 +4024,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3696,8 +4046,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.regexp.python</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.regexp.python</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3750,9 +4109,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3772,8 +4131,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.rust</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.rust</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3826,15 +4194,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -3848,8 +4216,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.scala</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.scala</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3902,9 +4279,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -3924,8 +4301,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.shell</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.shell</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -3978,9 +4364,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4000,8 +4386,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.ts</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.ts</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4054,9 +4449,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4076,8 +4471,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.tsx</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.tsx</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4130,9 +4534,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4152,8 +4556,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.typst</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.typst</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4206,15 +4619,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -4228,8 +4641,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.cs</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.cs</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4282,15 +4704,15 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(\/\/\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
                   <dict>
                     <key>name</key>
-                    <string>comment.line.number-sign.quarto</string>
+                    <string>comment.line.double-slash.quarto</string>
                   </dict>
                 </dict>
                 <key>contentName</key>
@@ -4304,8 +4726,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.fsharp</string>
+                <key>begin</key>
+                <string>^(?!\s*\/\/\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.fsharp</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4358,9 +4789,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4380,8 +4811,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.dart</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.dart</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4434,9 +4874,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4456,8 +4896,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.html.handlebars</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.html.handlebars</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4510,9 +4959,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4532,8 +4981,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.html.markdown</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.html.markdown</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4586,9 +5044,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4608,8 +5066,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.log</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.log</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4662,9 +5129,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4684,8 +5151,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.erlang</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.erlang</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4738,9 +5214,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4760,8 +5236,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>source.elixir</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.elixir</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4814,9 +5299,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4836,8 +5321,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.tex.latex</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.tex.latex</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -4890,9 +5384,9 @@
             <array>
               <dict>
                 <key>begin</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>while</key>
-                <string>^(\s*)(#\|)</string>
+                <string>^(\s*)(#\s*\| ?)</string>
                 <key>captures</key>
                 <dict>
                   <key>2</key>
@@ -4912,8 +5406,17 @@
                 </array>
               </dict>
               <dict>
-                <key>include</key>
-                <string>text.bibtex</string>
+                <key>begin</key>
+                <string>^(?!\s*#\s*\| ?)</string>
+                <key>while</key>
+                <string>(^|\G)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>text.bibtex</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>

--- a/apps/vscode/syntaxes/quarto.tmLanguage
+++ b/apps/vscode/syntaxes/quarto.tmLanguage
@@ -173,6 +173,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.css</string>
               </dict>
@@ -225,6 +248,29 @@
             <string>meta.embedded.block.html</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>text.html.basic</string>
@@ -279,6 +325,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.ini</string>
               </dict>
@@ -331,6 +400,29 @@
             <string>meta.embedded.block.java</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.java</string>
@@ -385,6 +477,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.lua</string>
               </dict>
@@ -437,6 +552,29 @@
             <string>meta.embedded.block.makefile</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.makefile</string>
@@ -491,6 +629,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.perl</string>
               </dict>
@@ -543,6 +704,29 @@
             <string>meta.embedded.block.prql</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.prql</string>
@@ -597,6 +781,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.r</string>
               </dict>
@@ -649,6 +856,29 @@
             <string>meta.embedded.block.julia</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.julia</string>
@@ -703,6 +933,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.matlab</string>
               </dict>
@@ -755,6 +1008,29 @@
             <string>meta.embedded.block.stata</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.stata</string>
@@ -809,6 +1085,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.dot</string>
               </dict>
@@ -861,6 +1160,29 @@
             <string>meta.embedded.block.mermaid</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.mmd</string>
@@ -915,6 +1237,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.wsd</string>
               </dict>
@@ -968,6 +1313,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.ruby</string>
               </dict>
@@ -1020,6 +1388,29 @@
             <string>meta.embedded.block.php</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>text.html.basic</string>
@@ -1078,6 +1469,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.sql</string>
               </dict>
@@ -1130,6 +1544,29 @@
             <string>meta.embedded.block.vs_net</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.asp.vb.net</string>
@@ -1184,6 +1621,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>text.xml</string>
               </dict>
@@ -1236,6 +1696,29 @@
             <string>meta.embedded.block.xsl</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>text.xml.xsl</string>
@@ -1290,6 +1773,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.yaml</string>
               </dict>
@@ -1342,6 +1848,29 @@
             <string>meta.embedded.block.dosbatch</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.batchfile</string>
@@ -1396,6 +1925,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.clojure</string>
               </dict>
@@ -1448,6 +2000,29 @@
             <string>meta.embedded.block.coffee</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.coffee</string>
@@ -1502,6 +2077,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.c</string>
               </dict>
@@ -1554,6 +2152,29 @@
             <string>meta.embedded.block.cpp source.cpp</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.cpp</string>
@@ -1608,6 +2229,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.diff</string>
               </dict>
@@ -1660,6 +2304,29 @@
             <string>meta.embedded.block.dockerfile</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.dockerfile</string>
@@ -1714,6 +2381,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>text.git-commit</string>
               </dict>
@@ -1766,6 +2456,29 @@
             <string>meta.embedded.block.git_rebase</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>text.git-rebase</string>
@@ -1820,6 +2533,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.go</string>
               </dict>
@@ -1872,6 +2608,29 @@
             <string>meta.embedded.block.groovy</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.groovy</string>
@@ -1926,6 +2685,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>text.pug</string>
               </dict>
@@ -1978,6 +2760,29 @@
             <string>meta.embedded.block.javascript</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.js</string>
@@ -2032,6 +2837,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.js.regexp</string>
               </dict>
@@ -2084,6 +2912,29 @@
             <string>meta.embedded.block.json</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.json</string>
@@ -2138,6 +2989,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.json.comments</string>
               </dict>
@@ -2190,6 +3064,29 @@
             <string>meta.embedded.block.less</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.css.less</string>
@@ -2244,6 +3141,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.objc</string>
               </dict>
@@ -2296,6 +3216,29 @@
             <string>meta.embedded.block.swift</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.swift</string>
@@ -2350,6 +3293,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.css.scss</string>
               </dict>
@@ -2402,6 +3368,29 @@
             <string>meta.embedded.block.perl6</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.perl.6</string>
@@ -2456,6 +3445,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.powershell</string>
               </dict>
@@ -2508,6 +3520,29 @@
             <string>meta.embedded.block.stan</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.stan</string>
@@ -2562,6 +3597,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.python</string>
               </dict>
@@ -2614,6 +3672,29 @@
             <string>meta.embedded.block.regexp_python</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.regexp.python</string>
@@ -2668,6 +3749,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.rust</string>
               </dict>
@@ -2720,6 +3824,29 @@
             <string>meta.embedded.block.scala</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.scala</string>
@@ -2774,6 +3901,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.shell</string>
               </dict>
@@ -2826,6 +3976,29 @@
             <string>meta.embedded.block.typescript</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.ts</string>
@@ -2880,6 +4053,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.tsx</string>
               </dict>
@@ -2932,6 +4128,29 @@
             <string>meta.embedded.block.typst</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.typst</string>
@@ -2986,6 +4205,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.cs</string>
               </dict>
@@ -3038,6 +4280,29 @@
             <string>meta.embedded.block.fsharp</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.fsharp</string>
@@ -3092,6 +4357,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.dart</string>
               </dict>
@@ -3144,6 +4432,29 @@
             <string>meta.embedded.block.handlebars</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>text.html.handlebars</string>
@@ -3198,6 +4509,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>text.html.markdown</string>
               </dict>
@@ -3250,6 +4584,29 @@
             <string>meta.embedded.block.log</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>text.log</string>
@@ -3304,6 +4661,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>source.erlang</string>
               </dict>
@@ -3356,6 +4736,29 @@
             <string>meta.embedded.block.elixir</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>source.elixir</string>
@@ -3410,6 +4813,29 @@
             <key>patterns</key>
             <array>
               <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>text.tex.latex</string>
               </dict>
@@ -3462,6 +4888,29 @@
             <string>meta.embedded.block.bibtex</string>
             <key>patterns</key>
             <array>
+              <dict>
+                <key>begin</key>
+                <string>^(\s*)(#\|)</string>
+                <key>while</key>
+                <string>^(\s*)(#\|)</string>
+                <key>captures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>comment.line.number-sign.quarto</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.yaml</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
               <dict>
                 <key>include</key>
                 <string>text.bibtex</string>


### PR DESCRIPTION
Fixes #409 

This is an alternative approach to https://github.com/quarto-dev/quarto/pull/1084.

This is a duplicate of https://github.com/quarto-dev/quarto/pull/1088, which I accidentally merged to main and then reverted. Sorry for confusion.

<img width="436" height="265" alt="Screenshot 2026-08-14 at 10 57 15 AM" src="https://github.com/user-attachments/assets/c21534e2-96a3-4ab0-8006-963da8bce4bc" />
<img width="441" height="264" alt="Screenshot 2026-08-14 at 11 01 56 AM" src="https://github.com/user-attachments/assets/ca4b5180-4c51-43c7-946f-97097f68b931" />

This PR is a very simple change: it adds a yaml injection language for #| comments. This means that our syntax highlighting will delegate to the yaml language highlighter inside of #| comments.


The quarto.tmLanguage change is generated from the build-lang.js script.

IMO this is a more "correct" approach, if you will. We lose control over how the yaml looks, but we shouldn't really have that control anyway (let yaml be yaml)?

### Pros
- very simple
- uses VSCode's yaml highlighting so it'll match frontmatter (which uses the same injection language approach) and yaml files

### Cons 

- yaml highlighting is a little visually intense in default themes (I attempted to address this by setting text opacity to 0.75 using a decoration. I have mild worries about contrast accessibility, perhaps we should add some configuration around this.).
- possibly has some weird edge cases? I expected multiline yaml stuff to not work well, but it seems to work just fine. I tried using some yaml-feature-test yaml as a hash pipe comment, and it worked well.

### Testing note

We could test that the generated tmLanguage delegates `#|` properly in some examples, in a non-integrated way, by using `vscode-textmate` and `vscode-oniguruma` as dependencies in the tests, but that seems a little heavy handed so I didn't do that.