### PR TITLE
positron testing: move from macos to ubuntu runners

### DIFF
--- a/.github/workflows/test-positron.yaml
+++ b/.github/workflows/test-positron.yaml
@@ -24,10 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
-      - name: Update build environment and install XVFB
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install --fix-missing xvfb
       - uses: quarto-dev/quarto-actions/setup@v2
       - name: Build vscode extension
         run: |
@@ -37,3 +33,5 @@ jobs:
         uses: posit-dev/setup-positron@v1
         with:
           positron-channel: stable
+          # Positron is an Electron app and needs a display server on Linux.
+          run: xvfb-run -a npm run test-positron

--- a/.github/workflows/test-positron.yaml
+++ b/.github/workflows/test-positron.yaml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
+      - name: Update build environment and install XVFB
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install --fix-missing xvfb
       - uses: quarto-dev/quarto-actions/setup@v2
       - name: Build vscode extension
         run: |

--- a/.github/workflows/test-positron.yaml
+++ b/.github/workflows/test-positron.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test-positron:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     name: Test Positron API
     steps:
       - uses: actions/checkout@v4
@@ -26,15 +26,10 @@ jobs:
           node-version: latest
       - uses: quarto-dev/quarto-actions/setup@v2
       - name: Build vscode extension
-        # macos-latest runners have ~7 GB RAM, so Node's default V8 heap limit
-        # (~2 GB) is too small for the vscode-editor vite build and it OOMs.
-        # Raise the limit to match what larger (ubuntu) runners get by default.
-        env:
-          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           yarn install
           yarn run build-vscode
       - name: Run Positron API tests
-        uses: posit-dev/setup-positron@main
+        uses: posit-dev/setup-positron@v1
         with:
           positron-channel: stable

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1546,7 +1546,7 @@
     "@types/uuid": "^9.0.0",
     "@types/vscode": "1.75.0",
     "@types/which": "^2.0.2",
-    "@posit-dev/positron-test-electron": "^0.0.2",
+    "@posit-dev/positron-test-electron": "^0.0.3",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "@vscode/test-cli": "^0.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,10 +2064,10 @@
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@posit-dev/positron-test-electron@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.2.tgz#509f1b56cb92342bdf0b2a8e707e4919ed2ad313"
-  integrity sha512-betE+lg9R6qom5cHafmimF9bJ9yWUhATj9JxzRNDAPCh9CLisQ8iSxfIv+RL+x+r7frGT0H018Y7ekb4JxW2vA==
+"@posit-dev/positron-test-electron@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.3.tgz#ba24b04984b62fa01a2d956948016dd97704eef3"
+  integrity sha512-MQYKCoB9JlGd70QLV0BVTezzGljIduLskeczDLVZ/4ECuYKAtuVFHvXFLDv5BUoarSxHkc0cT6r9k7DwrSni3A==
   dependencies:
     "@vscode/test-electron" "^2.4.1"
 


### PR DESCRIPTION
Updates related to https://github.com/posit-dev/positron/issues/15281

Moving to more cost-effective runners, and pinning to latest stable versions of tools