### PR TITLE
don't treat programmatic selection changes as cursor movement in AceNodeView

### DIFF
--- a/packages/editor/src/optional/ace/ace.ts
+++ b/packages/editor/src/optional/ace/ace.ts
@@ -530,9 +530,11 @@ export class AceNodeView implements NodeView {
 
     // If the cursor moves and we're in focus, ensure that the cursor is
     // visible. Ace's own cursor visiblity mechanisms don't work in embedded
-    // editors.
+    // editors. Selection changes we make ourselves (this.updating) don't count:
+    // those come from ProseMirror syncing its selection into the editor, not
+    // from the user moving the cursor.
     this.aceEditor.getSelection().on('changeCursor', () => {
-      if (this.dom.contains(document.activeElement) && !this.mouseDown) {
+      if (!this.updating && this.dom.contains(document.activeElement) && !this.mouseDown) {
         this.cursorDirty = true;
       }
     });


### PR DESCRIPTION
Fixes #1099.

`AceNodeView.setSelection()` sets `this.updating`, focuses the Ace editor and applies a selection range. That fires `changeCursor`, and the handler set `cursorDirty` without consulting `this.updating` — so the next Ace render called `scrollCursorIntoView()` and scrolled the editing root to that node view, even though nothing moved the cursor. The value-change handlers just above (L508/L513) already guard on `this.updating`; this one didn't.

ProseMirror calls `setSelection()` from `selectionToDOM()` on every `EditorView.focus()`, so any focus restore scrolled the document to whichever embedded editor held the selection. For a freshly opened document that selection is at position 0 — the YAML front matter block — so the document snapped to the very top. In RStudio this shows up as the visual editor jumping to the top of the document whenever you run a code chunk in a file you have just opened (rstudio/rstudio#18490); clicking once anywhere in the prose moves the selection out of an `AceNodeView` and the symptom disappears until the file is reopened.

### Verification

Tested against an RStudio development build by serving a patched `panmirror.js` to the browser and leaving everything else identical, measuring `.pm-scroll-container` scrollTop across a chunk run:

|          | run 1 | run 2 |
|----------|-------|-------|
| before   | jumps 215px to the top, then scrolls back | jumps 163px to the top, then scrolls back |
| after    | no movement | no movement |

Genuine cursor-driven scrollback is unchanged: scrolling a focused code chunk out of view and pressing an arrow key still brings the cursor back into view, identically before and after.

### Notes

No `apps/vscode/CHANGELOG.md` entry — `aceExtension` is only installed when `options.codeEditor === 'ace'` (`editor-extensions.ts:222`), which is RStudio's configuration; the VS Code and Positron visual editors use the CodeMirror code view and are unaffected. Happy to add an entry if you'd rather have one.
