### PR TITLE
Respect `quarto.cells.useReticulate` setting in Positron

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.138.0 (Unreleased)
 
+- In Positron, running a Python cell in a knitr document now respects the `quarto.cells.useReticulate` setting, instead of always routing it through reticulate on the R console (<https://github.com/quarto-dev/quarto/pull/1116>).
 
 ## 1.137.0 (Release on 2026-09-04)
 

--- a/apps/vscode/src/host/positron.ts
+++ b/apps/vscode/src/host/positron.ts
@@ -95,8 +95,13 @@ export function positronExtensionHost(outputChannel?: vscode.LogOutputChannel): 
                 return;
               }
 
-              if (language === "python" && isKnitrDocument(document, engine)) {
-                language = "r";
+              let executionLanguage = language;
+              if (
+                language === "python" &&
+                isKnitrDocument(document, engine) &&
+                vscode.workspace.getConfiguration("quarto").get("cells.useReticulate", true)
+              ) {
+                executionLanguage = "r";
                 blocks = blocks.map(pythonWithReticulate);
               }
 
@@ -119,7 +124,7 @@ export function positronExtensionHost(outputChannel?: vscode.LogOutputChannel): 
 
                   try {
                     await runtime.executeCode(
-                      language,   // The language ID
+                      executionLanguage, // The language ID
                       blocks[i],  // The code string to execute
                       false,      // Whether to focus the console
                       true,       // Whether to allow incomplete code to run
@@ -136,7 +141,7 @@ export function positronExtensionHost(outputChannel?: vscode.LogOutputChannel): 
                     if (!runtimeFailure) {
                       // The code couldn't be submitted to the runtime. Log it
                       // and let it propagate so the user finds out.
-                      outputChannel?.error(`Failed to execute ${language} cell: ${message}`);
+                      outputChannel?.error(`Failed to execute ${executionLanguage} cell: ${message}`);
                       throw err;
                     }
 
@@ -145,7 +150,7 @@ export function positronExtensionHost(outputChannel?: vscode.LogOutputChannel): 
                     // record but don't let it propagate to the command handler,
                     // which would surface it again as a notification popup.
                     // https://github.com/posit-dev/positron/issues/9845
-                    outputChannel?.debug(`Error executing ${language} cell: ${message}`);
+                    outputChannel?.debug(`Error executing ${executionLanguage} cell: ${message}`);
 
                     // Stop executing any subsequent blocks since one failed.
                     break;
@@ -153,7 +158,7 @@ export function positronExtensionHost(outputChannel?: vscode.LogOutputChannel): 
                 }
               };
 
-              await ExecuteQueue.instance.add(language, callback);
+              await ExecuteQueue.instance.add(executionLanguage, callback);
             },
             executeSelection: async (): Promise<void> => {
               await vscode.commands.executeCommand('workbench.action.positronConsole.executeCode', { languageId: language });

--- a/apps/vscode/src/test/positron/execute-cell.test.ts
+++ b/apps/vscode/src/test/positron/execute-cell.test.ts
@@ -38,7 +38,7 @@ suite("Positron: cell execution", function () {
 
   // `acquirePositronApi` is injected onto the global by Positron; we swap it for
   // a spy during each test and must restore it afterwards.
-  const globalWithApi = globalThis as { acquirePositronApi?: () => unknown };
+  const globalWithApi = globalThis as { acquirePositronApi?: () => unknown; };
   let originalAcquire: (() => unknown) | undefined;
 
   teardown(function () {
@@ -73,7 +73,7 @@ suite("Positron: cell execution", function () {
     // which we record instead of dispatching to a kernel.
     const calls: RuntimeCall[] = [];
     originalAcquire = globalWithApi.acquirePositronApi;
-    const realApi = originalAcquire!() as { runtime: Record<string, unknown> };
+    const realApi = originalAcquire!() as { runtime: Record<string, unknown>; };
     const fakeRuntime = new Proxy(realApi.runtime, {
       get(target, prop, receiver) {
         if (prop === "executeCode") {
@@ -134,7 +134,7 @@ suite("Positron: cell execution", function () {
     assert.ok(
       call,
       "Running the cell should call positron.runtime.executeCode('python', ...). " +
-        `Observed: ${describe(calls)}`
+      `Observed: ${describe(calls)}`
     );
 
     const code = String(call!.args[1]);
@@ -171,7 +171,7 @@ suite("Positron: cell execution", function () {
     assert.ok(
       call,
       "A knitr Python cell should be submitted to executeCode('r', ...). " +
-        `Observed: ${describe(calls)}`
+      `Observed: ${describe(calls)}`
     );
 
     const code = String(call!.args[1]);
@@ -183,6 +183,59 @@ suite("Positron: cell execution", function () {
       code.includes(`${marker} = 42`),
       "the original Python code should be embedded in the reticulate call"
     );
+  });
+
+  test("submits a knitr Python cell as python when cells.useReticulate is false", async function () {
+    const config = vscode.workspace.getConfiguration("quarto");
+    const previous = config.get<boolean>("cells.useReticulate");
+    await config.update(
+      "cells.useReticulate",
+      false,
+      vscode.ConfigurationTarget.Global
+    );
+    try {
+      const marker = `qmd_marker_${Date.now()}`;
+      const qmd = [
+        "---",
+        "engine: knitr",
+        "---",
+        "",
+        "```{python}",
+        `${marker} = 42`,
+        "```",
+        "",
+      ].join("\n");
+      // Cursor on the statement (line 5).
+      const calls = await runCellAndCaptureCalls(qmd, 5);
+
+      const rCall = calls.find(
+        (c) => c.method === "executeCode" && c.args[0] === "r"
+      );
+      assert.ok(
+        !rCall,
+        "With cells.useReticulate=false, a knitr Python cell should not be " +
+        `submitted to the R runtime. Observed: ${describe(calls)}`
+      );
+
+      const pyCall = calls.find(
+        (c) => c.method === "executeCode" && c.args[0] === "python"
+      );
+      assert.ok(
+        pyCall,
+        "With cells.useReticulate=false, a knitr Python cell should be " +
+        `submitted to executeCode('python', ...). Observed: ${describe(calls)}`
+      );
+      assert.ok(
+        !String(pyCall!.args[1]).includes("reticulate::repl_python"),
+        "the code should not be wrapped in reticulate::repl_python(...)"
+      );
+    } finally {
+      await config.update(
+        "cells.useReticulate",
+        previous,
+        vscode.ConfigurationTarget.Global
+      );
+    }
   });
 });
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6675 in part

This PR fixes a bug in Positron. Before this change, Positron ignored the `quarto.cells.useReticulate` setting. When you ran a Python cell in a document with `engine: knitr`, Positron always rewrote the code to run in the R console through `reticulate::repl_python(...)`. The setting had no effect. Now the Positron cell execution path checks the same setting that the default VS Code host already uses.

I also added a regression test. The test runs a knitr Python cell with the setting off. It shows that the cell executes in the Python console instead of R.

## Known limitation

This change does not solve the full problem in the issue about the difference between running a statement and Run Cell. In Positron, <kbd>Cmd+Enter</kbd> (run the current statement) sends the command to Positron core's `positron.executeCodeFromPosition` command. This command always runs Python cells on the Python console. It does not check the `quarto.cells.useReticulate` setting, and this extension has no hook to change that path. As a result, with the setting on, Run Cell now goes to R through reticulate, but Run Line still goes to Python. A fix for that part of the issue needs a change in Positron itself.

## Validation steps

- `yarn test-positron` passes (includes the new test)

- With a `.qmd` file that has both an `r` chunk and a `python` chunk:

  - With the setting on (the default), running a knitr Python cell with <kbd>Cmd+Shift+Enter</kbd> runs it via R through reticulate:

<img width="1405" height="784" alt="Screenshot 2026-09-08 at 3 55 54 PM" src="https://github.com/user-attachments/assets/b8df2a80-382f-47aa-abab-230ed588b09e" />

  - With the setting off, the same cell runs directly in the **Python** console:
 
<img width="1405" height="784" alt="Screenshot 2026-09-08 at 4 04 24 PM" src="https://github.com/user-attachments/assets/30a21c1f-78fc-4e6f-b6be-f948a63210ae" />

  - R cells run the same way, with the setting on or off

  - Switching the setting on and off again repeats this same behavior each time

