### PR TITLE
Enable Render on Save toggle in visual editor

### DIFF
--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.138.0 (Unreleased)
 
 - In Positron, running a Python cell in a knitr document now respects the `quarto.cells.useReticulate` setting, instead of always routing it through reticulate on the R console (<https://github.com/quarto-dev/quarto/pull/1116>).
+- In Positron, fixed how the "Render on Save" checkbox works in the visual editor (<https://github.com/quarto-dev/quarto/pull/1121>).
 
 ## 1.137.0 (Release on 2026-09-04)
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -456,7 +456,7 @@
         "command": "quarto.toggleRenderOnSave",
         "title": "Render on Save",
         "category": "Quarto",
-        "enablement": "editorLangId == quarto",
+        "enablement": "editorLangId == quarto || activeCustomEditorId == 'quarto.visualEditor'",
         "actionBarOptions": {
           "controlType": "checkbox",
           "checked": "(quarto.editor.type == quarto && quarto.editor.renderOnSave) || (quarto.editor.type == 'quarto-shiny' && quarto.editor.renderOnSaveShiny)"

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -32,24 +32,34 @@ export function activateContextKeySetter(
   engine: MarkdownEngine
 ) {
   // set the initial context keys
-  setEditorContextKeys(vscode.window.activeTextEditor, engine);
-  setLanguageContextKeys(vscode.window.activeTextEditor, engine);
+  setEditorContextKeys(vscode.window.activeTextEditor?.document, engine);
+  setLanguageContextKeys(vscode.window.activeTextEditor?.document, engine);
 
   // register for quarto.render.renderOnSave or quarto.render.renderOnSaveShiny configuration change notification
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
     // if the change affects quarto.render.renderOnSave or quarto.render.renderOnSaveShiny, set the editor context keys.
     if (event.affectsConfiguration('quarto.render.renderOnSave') || event.affectsConfiguration('quarto.render.renderOnSaveShiny')) {
-      setEditorContextKeys(vscode.window.activeTextEditor, engine);
+      const document = vscode.window.activeTextEditor?.document ?? VisualEditorProvider.activeEditor()?.document;
+      setEditorContextKeys(document, engine);
     }
   }));
 
   // set context keys when active text editor changes
   vscode.window.onDidChangeActiveTextEditor(activeTextEditor => {
-    setEditorContextKeys(activeTextEditor, engine);
-    setLanguageContextKeys(activeTextEditor, engine);
+    setEditorContextKeys(activeTextEditor?.document, engine);
+    setLanguageContextKeys(activeTextEditor?.document, engine);
   },
     null,
     context.subscriptions
+  );
+
+  // set context keys when a visual editor becomes active (custom editors
+  // don't fire onDidChangeActiveTextEditor)
+  context.subscriptions.push(
+    VisualEditorProvider.onDidChangeActiveEditor()(editor => {
+      setEditorContextKeys(editor.document, engine);
+      setLanguageContextKeys(editor.document, engine);
+    })
   );
 
   // set context keys on changes to the document (if it's active)
@@ -59,8 +69,8 @@ export function activateContextKeySetter(
       // TODO: this debounce is being created and called immediately, which is not correct.
       debounce(
         () => {
-          setEditorContextKeys(activeEditor, engine);
-          setLanguageContextKeys(activeEditor, engine);
+          setEditorContextKeys(activeEditor.document, engine);
+          setLanguageContextKeys(activeEditor.document, engine);
         },
         debounceOnDidChangeDocumentMs
       )();
@@ -110,11 +120,11 @@ export function toggleRenderOnSaveOverride() {
 }
 
 // sets editor context keys
-function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, engine: MarkdownEngine) {
+function setEditorContextKeys(document: vscode.TextDocument | undefined, engine: MarkdownEngine) {
   // if a Quarto doc is active, set the editor context keys
-  if (isQuartoDoc(activeTextEditor?.document)) {
+  if (isQuartoDoc(document)) {
     // set the quarto.editor.type context key
-    quartoEditorType = !isQuartoShinyDoc(engine, activeTextEditor?.document)
+    quartoEditorType = !isQuartoShinyDoc(engine, document)
       ? 'quarto'
       : 'quarto-shiny';
     vscode.commands.executeCommand<string>(
@@ -145,13 +155,13 @@ function setEditorContextKeys(activeTextEditor: vscode.TextEditor | undefined, e
   }
 }
 
-function setLanguageContextKeys(activeTextEditor: vscode.TextEditor | undefined, engine: MarkdownEngine) {
-  if (!activeTextEditor || !isQuartoDoc(activeTextEditor.document)) {
+function setLanguageContextKeys(document: vscode.TextDocument | undefined, engine: MarkdownEngine) {
+  if (!document || !isQuartoDoc(document)) {
     return;
   }
 
   // expose main language for use in keybindings, etc
-  const tokens = engine.parse(activeTextEditor.document);
+  const tokens = engine.parse(document);
   const language = mainLanguage(tokens);
   vscode.commands.executeCommand(
     'setContext',

--- a/apps/vscode/src/providers/context-keys.ts
+++ b/apps/vscode/src/providers/context-keys.ts
@@ -56,7 +56,7 @@ export function activateContextKeySetter(
   // set context keys when a visual editor becomes active (custom editors
   // don't fire onDidChangeActiveTextEditor)
   context.subscriptions.push(
-    VisualEditorProvider.onDidChangeActiveEditor()(editor => {
+    VisualEditorProvider.onDidChangeActiveEditor(editor => {
       setEditorContextKeys(editor.document, engine);
       setLanguageContextKeys(editor.document, engine);
     })

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -26,7 +26,9 @@ import {
   Selection,
   TextEditorRevealType,
   GlobPattern,
-  TabInputText
+  TabInputText,
+  Event,
+  EventEmitter
 } from "vscode";
 
 import { projectDirForDocument, QuartoContext } from "quarto-core";
@@ -266,6 +268,11 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
 
   public static recordPendingSwitchToVisual(document: TextDocument) {
     this.editorPendingSwitchToVisual.add(document.uri.toString());
+  }
+
+  // fires when a visual editor's webview panel becomes active
+  public static onDidChangeActiveEditor(): Event<TrackedEditor> {
+    return this.visualEditors.onDidChangeActiveEditor;
   }
 
   public static activeEditor(includeVisible?: boolean): QuartoVisualEditor | undefined {
@@ -677,17 +684,27 @@ interface VisualEditorTracker {
   track: (document: TextDocument, webviewPanel: WebviewPanel, editor: VSCodeVisualEditor) => Disposable;
   editorForUri: (uri: Uri) => TrackedEditor | undefined;
   activeEditor: (includeVisible?: boolean) => TrackedEditor | undefined;
+  onDidChangeActiveEditor: Event<TrackedEditor>;
 }
 
 function visualEditorTracker(): VisualEditorTracker {
 
   const activeEditors = new Array<TrackedEditor>();
+  const onDidChangeActiveEditorEmitter = new EventEmitter<TrackedEditor>();
 
   return {
     track: (document: TextDocument, webviewPanel: WebviewPanel, editor: VSCodeVisualEditor): Disposable => {
-      activeEditors.push({ document, webviewPanel, editor });
+      const trackedEditor = { document, webviewPanel, editor };
+      activeEditors.push(trackedEditor);
+      // notify when this editor's webview panel becomes active
+      const viewStateDisposable = webviewPanel.onDidChangeViewState(e => {
+        if (e.webviewPanel.active) {
+          onDidChangeActiveEditorEmitter.fire(trackedEditor);
+        }
+      });
       return {
         dispose: () => {
+          viewStateDisposable.dispose();
           const idx = activeEditors.findIndex(editor => editor.webviewPanel === webviewPanel);
           if (idx !== -1) {
             activeEditors.splice(idx, 1);
@@ -711,7 +728,8 @@ function visualEditorTracker(): VisualEditorTracker {
         }
 
       });
-    }
+    },
+    onDidChangeActiveEditor: onDidChangeActiveEditorEmitter.event
   };
 }
 

--- a/apps/vscode/src/providers/editor/editor.ts
+++ b/apps/vscode/src/providers/editor/editor.ts
@@ -271,9 +271,8 @@ export class VisualEditorProvider implements CustomTextEditorProvider {
   }
 
   // fires when a visual editor's webview panel becomes active
-  public static onDidChangeActiveEditor(): Event<TrackedEditor> {
-    return this.visualEditors.onDidChangeActiveEditor;
-  }
+  public static readonly onDidChangeActiveEditor: Event<TrackedEditor> =
+    VisualEditorProvider.visualEditors.onDidChangeActiveEditor;
 
   public static activeEditor(includeVisible?: boolean): QuartoVisualEditor | undefined {
     const editor = this.visualEditors.activeEditor(includeVisible);


### PR DESCRIPTION
The **Render on Save** checkbox appears in the visual editor's action bar, but it wasn't correctly working there. This PR makes the checkbox (more) correctly functional in the visual editor. I'll be honest that there is still some weirdness with the `quarto.render.renderOnSave` setting, but this is an improvement.

This is the Quarto-side follow-up called out in https://github.com/posit-dev/positron/pull/16022, which is making extension-contributed action bar checkboxes follow their command's `enablement` expression. cc @dhruvisompura

## Root cause

Two issues:

1. The `quarto.toggleRenderOnSave` command's `enablement` was `editorLangId == quarto`, which doesn't match when the visual editor (a custom editor) is active so the checkbox was not fully/correctly enabled there.
2. The `quarto.editor.type` / `quarto.editor.renderOnSave` / `quarto.editor.renderOnSaveShiny` context keys that drive the checkbox's checked state were only updated via `onDidChangeActiveTextEditor`, which custom editors don't fire, so the state was stale even where the checkbox was visible.

## Changes

- `package.json`: add `activeCustomEditorId == 'quarto.visualEditor'` to the command's `enablement`, matching the pattern used by other menu contributions.
- `editor.ts`: add an `onDidChangeActiveEditor` event to the visual editor tracker, fired from each tracked webview panel's `onDidChangeViewState` when its panel becomes active, and expose it via `VisualEditorProvider.onDidChangeActiveEditor()`.
- `context-keys.ts`: refactor `setEditorContextKeys` / `setLanguageContextKeys` to take a `TextDocument` (they only ever used the document), subscribe to the new event so context keys refresh when a visual editor gains focus, and fall back to the active visual editor's document in the configuration-change listener.

## Validation

- Open a `.qmd` in visual mode: the checkbox appears and is clickable.
- Toggle the checkbox in visual mode and save: render kicks off when checked, doesn't when unchecked.
- Toggle in visual mode, switch to source mode (and back): state carries across.
- Regression: source-mode behavior unchanged; checkbox stays hidden for non-Quarto files.