### PR TITLE
Fix LSP crash on unparseable cell option YAML by handling null lint result

### DIFF
--- a/apps/lsp/src/quarto.ts
+++ b/apps/lsp/src/quarto.ts
@@ -38,7 +38,7 @@ export interface Quarto extends QuartoContext {
     token: AttrToken,
     context: EditorContext
   ): Promise<CompletionItem[]>;
-  getYamlDiagnostics(context: EditorContext): Promise<LintItem[] | null>;
+  getYamlDiagnostics(context: EditorContext): Promise<LintItem[]>;
   getHover?: (context: EditorContext) => Promise<HoverResult | null>;
 }
 
@@ -50,7 +50,9 @@ export async function initializeQuarto(context: QuartoContext): Promise<Quarto> 
     getAttrCompletions: initializeAttrCompletionProvider(
       context.resourcePath
     ),
-    getYamlDiagnostics: quartoModule.getLint,
+    // the external getLint() resolves to null when linting fails
+    getYamlDiagnostics: async (context) =>
+      (await quartoModule.getLint(context)) ?? [],
     getHover: quartoModule.getHover
   };
 

--- a/apps/lsp/src/quarto.ts
+++ b/apps/lsp/src/quarto.ts
@@ -38,7 +38,7 @@ export interface Quarto extends QuartoContext {
     token: AttrToken,
     context: EditorContext
   ): Promise<CompletionItem[]>;
-  getYamlDiagnostics(context: EditorContext): Promise<LintItem[]>;
+  getYamlDiagnostics(context: EditorContext): Promise<LintItem[] | null>;
   getHover?: (context: EditorContext) => Promise<HoverResult | null>;
 }
 
@@ -168,7 +168,7 @@ function normalizedValue(value: string, simpleDiv: boolean) {
 
 interface QuartoYamlModule {
   getCompletions(context: EditorContext): Promise<CompletionResult>;
-  getLint(context: EditorContext): Promise<Array<LintItem>>;
+  getLint(context: EditorContext): Promise<Array<LintItem> | null>;
   getHover?: (context: EditorContext) => Promise<HoverResult | null>;
 }
 

--- a/apps/lsp/src/service/providers/diagnostics-yaml.ts
+++ b/apps/lsp/src/service/providers/diagnostics-yaml.ts
@@ -26,7 +26,7 @@ export async function provideYamlDiagnostics(
 ): Promise<Diagnostic[]> {
 
   const context = docEditorContext(doc, Position.create(0, 0), true);
-  const diagnostics = await quarto.getYamlDiagnostics(context);
+  const diagnostics = (await quarto.getYamlDiagnostics(context)) ?? [];
   return diagnostics.map((item) => {
     return {
       severity: lintSeverity(item),

--- a/apps/lsp/src/service/providers/diagnostics-yaml.ts
+++ b/apps/lsp/src/service/providers/diagnostics-yaml.ts
@@ -26,7 +26,7 @@ export async function provideYamlDiagnostics(
 ): Promise<Diagnostic[]> {
 
   const context = docEditorContext(doc, Position.create(0, 0), true);
-  const diagnostics = (await quarto.getYamlDiagnostics(context)) ?? [];
+  const diagnostics = await quarto.getYamlDiagnostics(context);
   return diagnostics.map((item) => {
     return {
       severity: lintSeverity(item),

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - In Positron, running a Python cell in a knitr document now respects the `quarto.cells.useReticulate` setting, instead of always routing it through reticulate on the R console (<https://github.com/quarto-dev/quarto/pull/1116>).
 - In Positron, when Positron serves language features for code cells itself (the `quarto.embeddedLanguageFeatures.native` setting), the extension no longer serves them from virtual document temp files (<https://github.com/quarto-dev/quarto/pull/1115>).
+- Fixed a crash of the Quarto language server on save when a code cell contained unparseable YAML options (e.g. an unquoted `fig-cap` value containing a colon) (<https://github.com/quarto-dev/quarto/pull/1123>).
 
 ## 1.137.0 (Release on 2026-09-04)
 


### PR DESCRIPTION
Fixes #1118 (the upstream report is from posit-dev/positron#15965)

This PR fixes a Quarto LSP server crash that occurred when saving a document containing unparseable YAML in code cell options (for example, a `%%| fig-cap:` value containing an unquoted colon). After five crashes in three minutes, the client stops restarting the server and all language features are lost until reload.

## Root cause

When cell option YAML fails to parse, `getLint()` in the bundled `vs-code.mjs` module catches the resulting `YAMLException`, logs "Error found during linting", and resolves to `null`. The on-save diagnostics path in `provideYamlDiagnostics` then called `.map()` on that `null` value, throwing a `TypeError` that crashed the language server:

```
Error found during linting [YAMLException: bad indentation of a mapping entry ...]
TypeError: Cannot read properties of null (reading 'map')
    at computeOnSaveDiagnostics (.../lsp.js)
```

The other caller of `getYamlDiagnostics` (in `apps/lsp/src/custom.ts`) already handled `null` correctly, which is why this only crashed on save.

I verified against the reproduction document in #1118, and now saving no longer crashes the server.

## A possible follow-up

With this fix, a document with broken cell option YAML silently produces no YAML diagnostics on save (the parse error is only logged to the Output channel). A future improvement could surface the parse error as a diagnostic using the position info in the `YAMLException`; that requires changes in the Quarto CLI, where the exception is currently swallowed. The null guard here is still valuable regardless.